### PR TITLE
Adding geoapi notebooks for icenet-geoapi integration testing

### DIFF
--- a/geoapi/api-usage-historic-forecasts.ipynb
+++ b/geoapi/api-usage-historic-forecasts.ipynb
@@ -1,0 +1,380 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a4ce6500",
+   "metadata": {},
+   "source": [
+    "# Using the IceNet API for historic forecasts\n",
+    "This notebook will explain how to retrieve historic `IceNet` data from the public API and display it locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5cd61024",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required modules\n",
+    "import datetime\n",
+    "import requests\n",
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a9da189e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the base URL for API requests\n",
+    "api_base_url = \"https://app-icenetgeoapi-pygeoapi.azurewebsites.net/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e853f2dc",
+   "metadata": {},
+   "source": [
+    "Let's see how the prediction for a particular cell changes over time. First, let's identify a cell in the Bering Sea (close to 53, -170)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7e40768f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{api_base_url}/collections/north_forecasts_historic/items?bbox=-170.1,52.9,-169.9,53.1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a067b5a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80840\n"
+     ]
+    }
+   ],
+   "source": [
+    "cell_id = response.json()[\"features\"][0][\"properties\"][\"cell_id\"]\n",
+    "print(cell_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0a4dd1a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve the cell\n",
+    "response = requests.get(f\"{api_base_url}/collections/north_cells/items?cell_id={cell_id}\")\n",
+    "geodata = gpd.GeoDataFrame.from_features(response.json(), crs=\"EPSG:4326\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "93cb2a7b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeoAAAJCCAYAAAAPyoQkAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAkE0lEQVR4nO3de3Cd+X3f988XBEmQ4G1JgtRqL9rd6tZUympkRlZrxbasRI0VW0qnraPEbpSLu2Mn4zqephq7bv+op5nxuJnUyrRTZ5vGY0+sxI7jjTVJLEuRo9bpVLJ3bdlaayVbWi2Xl10C4JLL5f2CX//AIU1SIAGSODg/AK/XDAcH5zwPzvfh4eEbz3MOHlRrLQBAn8ZGPQAAcGtCDQAdE2oA6JhQA0DHhBoAOibUANCxJYW6qnZV1S9X1Zer6rmq+o+randVfbqq/mjw8b5hDwsA681S96g/luSTrbW3Jnk8yXNJfjTJZ1prb0rymcHnAMAyqsVOeFJVO5N8Iclj7bqFq+orSb69tfZSVd2f5LOttbcMc1gAWG/Gl7DMo0lmkvxsVT2e5JkkP5xkf2vtpcEyLyfZv9DKVfVEkieSZHJy8pve+ta33vPQAEtx+fLlXLp0acXvd9OmTdmwYcOK32+SXLlyJRcvXhzJfd+sqjI2NpYrV66MepSh+dKXvjTbWpsa5n0sZY/6QJLPJfmW1trnq+pjSU4l+aHW2q7rljvRWrvt69QHDhxoTz/99L1PDbBEZ86cyaFDh3L58uUVu899+/Zl3759K3Z/Nztz5kwOHjyYubm5Fb3fjRs3ZnJyMlu3bs3k5GQ2bdqUqhrZPCvh7W9/+zOttQPDvI+l7FEfTnK4tfb5wee/nPnXo49V1f3XHfqeHtaQAHdrcnIyb3zjGzMzM5NXXnklK/H7DS5cuDD0+7idycnJPProo3nhhReGuje7adOmTE5OXovzpk2bbjnPY489lhdeeGFFv2FaKxYNdWvt5ao6VFVvaa19Jcn7knxp8OcjSX5y8PFXhzopwF0aHx/P/fffn6mpqRw/fjzHjx8f2t7d2NhYNm/ePJSvfSe2bNlyLY7Ldfh/8+bNN4R548aNS153YmLi2jy9HJpfLZayR50kP5TkF6pqU5Lnk/y1zL9j/Jeq6m8kOZjke4YzIsDyGB8fz/79+7N3796cOHEis7Ozy7aHt3nz5uzevTu7du0a2evTN9u8efO1ON7NXv7ExMQNYR4fX2oyFrZp06Zr85w/f/6evtZ6sqS/9dbaF5IsdAz+fcs6DcAK2LBhQ/bu3Zvdu3fn5MmTmZ2dveu9vB07dmT37t2ZnJxMVS3zpPdu48aNefTRR3Pw4MGcO3futstu2bLlhjAP4xuO8fHxPProo3nxxRdz5syZZf/6a9G9fXsEsIqNjY1l9+7due+++3Lq1KnMzMwsaU9vw4YN19a71euyPbk+jqdPn04y/47sm8M8NrYyJ6vcsGFD3vCGN+Tw4cM5derUitznaibUwLpXVdm5c2d27NiR06dPZ2ZmJmfPnv2G5bZs2ZI9e/Zkx44dKxa15TI2NpaHH344J06cyMTERLZs2TLSbRgbG8tDDz2Uo0eP5sSJEyObYzUQaoCBqsr27duzffv2nD17NjMzMzl9+nR27tyZPXv2ZMuWLaMe8Z6MjY1lz549ox7jmqrK61//+oyPj2dmZmbU43RLqAEWsHXr1rzhDW/I3Nzcqtt7Xk2qKvv378/4+HheeumlxVdYh/zrA7gNkV4Ze/bsyYMPPtjlG/JGzb9AALqwa9euPPzww2J9E6EGoBvbt2/Po48+2s3PovdAqAHoytatW/Pwww+PeoxuCDUA3XGa0T8m1AB057XXXhv1CN0QagC6Mjc3d+0Magg1AJ05e/bsmvzd1XdLqAHoisPeNxJqALrRWvOLOm4i1AB048KFC7l06dKox+iKUAPQDYe9v5FQA9ANof5GQg1AFy5fvrzg7wFf74QagC742emFCTUAXXDYe2FCDcDItdaE+haEGoAutNZGPUKXhBqAkauqjI+Pj3qMLgk1AF0Q6oUJNQBdEOqFCTUAXdiwYcOoR+iSUAPQBXvUCxNqALog1AsTagC60FOoN2zYkIceeihTU1OjHiX9/K0AsK71EuqdO3fm/vvvz/j4eLZu3ZrZ2dmR/ox3H38rAKx7ow71+Ph4Xv/612fHjh3Xrtu4cWN27dqVEydOjG6ukd0zAFxnlKG+fi/6Znv27BFqABjFj2cttBd9s4mJiWzfvn1k5yIXagC6UFXZsGFDrly5siL3t2vXrtx///1L+gZh7969Qg0A4+PjQw/1+Ph4HnjggWzfvn3J62zdujVbtmzJuXPnhjjZwvx4FgDdGPbr1Lt27cqb3vSmO4p0Mr+3v3fv3iFNdXv2qAHoxrBCfTd70TfbsWNHNm7cmEuXLi3jZIuzRw1AN4YR6vvuu++u9qJvVlXZs2fPMk21dPaoAejGcr7ze+PGjXnggQeybdu2Zfua9913X6anpzM3N7dsX3MxQg1AN5Zrj3r37t3Zv3//sv/I14YNG7J79+7Mzs4u69e9HaEGoBv3Guph7EXfbM+ePTl+/PiKnVZUqAHoxr2Eelh70TfbuHFjdu7cmZMnTw71fq4SagC6sXnz5jz00ENL3lu9utzmzZuzdevWYY52g7179wo1AOvPhg0bsnPnzlGPsaiJiYmhHl6/nh/PAoC7sFInQBFqALgLk5OTK3I/Qg0Ad6GqVuR+hBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADo2vpSFquqFJK8luZLkcmvtQFW9I8nPJJlIcjnJ32yt/daQ5gSAdWlJoR54b2tt9rrPfyrJ/9Ra+7Wq+sDg829fzuEAYL27l0PfLcmOweWdSY7e+zgAwPWWukfdknyqqlqSf9haezLJ307y61X19zIf/P9koRWr6okkTyTJww8/fM8DA8B6stQ96ve01t6Z5DuT/K2q+tYkP5jkR1prDyX5kST/10IrttaebK0daK0dmJqaWpahAWC9WFKoW2tHBh+nkzyV5F1JPpLkVwaL/PPBdQDAMlo01FU1WVXbr15O8v4kz2b+NelvGyz2HUn+aFhDAsB6tZTXqPcneaqqri7/8dbaJ6vqdJKPVdV4kvMZvA4NACyfRUPdWns+yeMLXP/vk3zTMIYCAOY5MxkAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAeAutNZW5H7GV+ReAGANuXjxYg4fPrwi9yXUAHAHrly5kq9//eu5dOnSityfQ98AsESttRw9enTFIp0INQAs2cmTJ/Pqq6+u6H0KNQAswYULF3L06NEVv1+hBoBFzM3N5dChQyv2Tu/rCTUALOLYsWM5f/78SO5bqAHgNl577bUcP358ZPcv1ABwC5cuXVqxn5e+FaEGgAW01nL48OFcuXJlpHMINQAsYHZ2NmfOnBn1GEINADc7e/Zsjh07Nuoxkgg1ANzgypUrOXTo0KjHuGZJoa6qF6rqi1X1hap6+rrrf6iqvlxVf1BVPzW8MQFg+EZxitDF3Mkv5Xhva2326idV9d4kH0ryeGvtQlXtW/bpAGAFjeIUoYu5l9+e9YNJfrK1diFJWmvTyzMSAKys1lrOnz+fl156adSjfIOlhrol+VRVtST/sLX2ZJI3J/nTVfV3k5xP8ndaa79984pV9USSJ5Lk4YcfXp6pAeAuXLlyJRcuXMiFCxdy8eLFGz6O4vSgS7HUUL+ntXZkcHj701X15cG6u5O8O8mfSvJLVfVYu2lLB1F/MkkOHDjQ598CAGvG3NxcLl269A1BvnDhwsh/JvpuLCnUrbUjg4/TVfVUknclOZzkVwZh/q2qmkuyN8nMsIYFgGT+UPXly5cX3DO+ePHiqMdbVouGuqomk4y11l4bXH5/kp9IcjrJe5P8u6p6c5JNSWZv/ZUA4M7Mzc0tuGd88eLFzM3NjXq8FbGUPer9SZ6qqqvLf7y19smq2pTkH1fVs0kuJvnIzYe9AeBunTlzJi+++OKqPFy9nBYNdWvt+SSPL3D9xSTfN4yhAFjfTpw4kaNHj3b7Bq+VdC8/ngUAy6q1lmPHjmV21iupVwk1AF2Ym5vL4cOHc+rUqVGP0hWhBmDkLl26lBdffDHnzp0b9SjdEWoARur8+fM5ePBgV+fX7olQAzAyr732Wg4dOrRuftTqbgg1ACNx/PjxLs+t3RuhBmBFtdby0ksv5ZVXXhn1KKuCUAOwYq5cuZJDhw7l9OnTox5lSXbu3Jm9e/dmbm4u58+fv+HPSv2Mt1ADsCIuXryYgwcP5sKFC6MeZVG7du3K1NRUNm/efO26ycnJa5dbayu2HUINwNCdPXs2Bw8e7P50oAsFeiFVlYmJiRWZSagBGKpXX301hw8f7vp0oPfdd1+mpqayadOmUY/yDYQagKForWVmZibT09OjHmVBVZX77rsve/fu7TLQVwk1AMtubm4uR48ezcmTJ0c9yjdYLYG+SqgBWFaXL1/Oiy++mLNnz456lBtcDfTU1FQ2btw46nGWTKgBWDYXLlzIwYMHc/HixVGPck1VZffu3dm7d++qCvRVQg3Asjh9+nRefPHFbk4HutoDfZVQA3DPXnnllRw9enTUYyRJxsbGrgV6fHz1Z271bwEAIzM3N5fp6enMzs6OepQkyZ49ezI1NbUmAn3V2tkSAFZMay0nT57M9PR0F7+ecseOHdm/f/+iJypZjYQagCVrreXUqVOZnp7u4lSgW7Zsyete97obTu+51gg1AItqreX06dM5duxYzp8/P+pxsnHjxrzuda/Ljh07UlWjHmeohBqA2zpz5kyOHTvWxc9Fj42NZd++fdm9e3fGxsZGPc6KEGoAFnTu3LkcO3asm19JuRbfKLYU62trAVjU+fPnMz09nVOnTo16lCRr+41iSyHUACSZ/33R09PT3Zyfez28UWwphBpgnbt06VJmZmZy4sSJLn4V5Xp6o9hSCDXAOnX58uXMzs7m+PHjXQR6Pb5RbCmEGmCduXLlSo4fP57Z2dkuzst99Zzc6/GNYkvhbwRgnZibm8srr7ySmZmZXLlyZdTjJPFGsaUQaoB14OzZszl8+HA3v35yYmIi999//7p/o9hSCDXAGtZay8zMTKanp0c9yjX79u3L3r17vQ69REINsEZdvHgxhw8f7uKMYsn8XvQDDzyQLVu2jHqUVUWoAdaY1lpeffXVHD16tIs3iyX2ou+FUAOsIVeuXMnRo0fz6quvjnqUJPail4NQA6wRp0+fzpEjR7r4/dDJ/F701NSUk5bcI6EGWOXm5uYyPT2d2dnZUY+SxF70chNqgFXs/PnzOXz4cBe/I7qqMjU1ZS96mQk1wCrUWssrr7ySl19+uYvTf05MTOTBBx/MxMTEqEdZc4QaYJW5fPlyjhw5ktdee23Uo9iLXgFCDbCKnDp1KkeOHOniFKD2oleGUAOsAnNzc3n55ZfzyiuvjHoUe9ErTKgBOnfu3LkcOnRo5Ofprqps27Yt+/fvtxe9goQaoFOttczOzubYsWMjm2FiYiLbtm3Ltm3bsnXrVmcWGwGhBujQqM7TvWHDhmth3rZtWzZu3Lii9883EmqAzpw8eXLFztNdVdm6deu1ME9MTHjduTNCDdCJlTpP96ZNm7J9+/Zs27Ytk5OTDmd3TqgBOlFVOXPmzLJ/3bGxsRsOZ2/atGnZ74PhEWqAToyNjWX//v05cuTIPX+t6w9nb9myxeHsVUyoATqya9euHD9+/I7P3b1x48Yb9po3bNgwpAlZaUIN0JGqyv3335+vf/3rt11ubGwsk5OTNxzOtte8Ngk1QGcmJyezY8eOnDp16obrr/5M8/bt27NlyxZvAlsnhBqgQ/v378+5c+du2GseH/df9nrkUQfo0ObNm/OWt7xl1GPQAcdNAKBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6NiSQl1VL1TVF6vqC1X19E23/bdV1apq73BGBID1605+Kcd7W2uz119RVQ8leX+SF5d1KgAgyb0f+v5fk3w0SVuGWQCAmyw11C3Jp6rqmap6Ikmq6kNJjrTWfu92K1bVE1X1dFU9PTMzc4/jAsD6stRD3+9prR2pqn1JPl1VX07y32f+sPdttdaeTPJkkhw4cMCeNwDcgSXtUbfWjgw+Tid5Ksm3JXk0ye9V1QtJHkzyO1X1uiHNCQDr0qKhrqrJqtp+9XLm96J/u7W2r7X2SGvtkSSHk7yztfbyUKcFgHVmKYe+9yd5qqquLv/x1tonhzoVAJBkCaFurT2f5PFFlnlkuQYCAP6YM5MBQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRsf9QDA8vnksy9n88axvO31OzO1ffOoxwGWgVDDGvKxz/xRnnvpVJLkdTsm8rYHduZtD+zI2x/Ymbc9sDP7d0yMeELgTgk1rBFzcy3Pz5y+9vnLp87n5VPn82+fO5YkeWj3lvzmR79jVOMBd8lr1LBGHDl5Lhcuz93y9jft276C0wDLRahhjfjadXvTC3njvm0rNAmwnIQa1oivzZy57e1vnBJqWI2EGtaIRfeo9ws1rEZCDWvE16Yd+oa1SKhhjfj67K0Pfe/fsTk7Jjau4DTAcvHjWbBG/Mbf+fb8wZFX8+zRU3n2yKv54pFX87WZ02nN3jSsZkINa8S2zeP55sf25Jsf23PtujMXLue5l07lylwb4WTAvRBqWMMmN4/nwCO7Rz0GcA+8Rg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6Nr6UharqhSSvJbmS5HJr7UBV/S9JvjvJxSRfS/LXWmsnhzQnAKxLd7JH/d7W2jtaawcGn386ydtaa38yyR8m+bFlnw4A1rm7PvTdWvtUa+3y4NPPJXlweUYCAK5aaqhbkk9V1TNV9cQCt//1JL+20IpV9URVPV1VT8/MzNztnACwLi011O9prb0zyXcm+VtV9a1Xb6iqH09yOckvLLRia+3J1tqB1tqBqampex4YANaTJYW6tXZk8HE6yVNJ3pUkVfVXk3xXku9trbUhzQgA69aioa6qyarafvVykvcnebaq/lySjyb5YGvt7HDHBID1aSk/nrU/yVNVdXX5j7fWPllVX02yOcmnB7d9rrX2A0ObFADWoUVD3Vp7PsnjC1z/xqFMBABc48xkANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADo2vpSFquqFJK8luZLkcmvtQFXtTvKLSR5J8kKS72mtnRjOmACwPt3JHvV7W2vvaK0dGHz+o0k+01p7U5LPDD4HAJbRvRz6/lCSnxtc/rkkf+GepwEAbrDUULckn6qqZ6rqicF1+1trLw0uv5xk/0IrVtUTVfV0VT09MzNzj+MCwPqypNeok7yntXakqvYl+XRVffn6G1trraraQiu21p5M8mSSHDhwYMFlAICFLWmPurV2ZPBxOslTSd6V5FhV3Z8kg4/TwxoSANarRUNdVZNVtf3q5STvT/Jskk8k+chgsY8k+dVhDQkA69VSDn3vT/JUVV1d/uOttU9W1W8n+aWq+htJDib5nuGNCQDr06Khbq09n+TxBa4/nuR9wxgKAJjnzGQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHlhzqqtpQVb9bVf9q8Pn7qup3quoLVfXvq+qNwxsTANanO9mj/uEkz133+f+R5Htba+9I8vEk/8MyzgUAZImhrqoHk/z5JP/ouqtbkh2DyzuTHF3e0QCA8SUu99NJPppk+3XXfX+Sf1NV55KcSvLuhVasqieSPJEkDz/88F0PCgDr0aJ71FX1XUmmW2vP3HTTjyT5QGvtwSQ/m+TvL7R+a+3J1tqB1tqBqampex4YANaTpexRf0uSD1bVB5JMJNlRVf86yVtba58fLPOLST45pBkBYN1adI+6tfZjrbUHW2uPJPlwkt9I8qEkO6vqzYPF/mxufKMZALAMlvoa9Q1aa5er6r9O8i+qai7JiSR/fVknAwDuLNSttc8m+ezg8lNJnlr+kQCAq5yZDAA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHlhzqqtpQVb9bVf9q8HlV1d+tqj+squeq6r8Z3pgAsD6N38GyP5zkuSQ7Bp//1SQPJXlra22uqvYt82wAsO4taY+6qh5M8ueT/KPrrv7BJD/RWptLktba9PKPBwDr21IPff90ko8mmbvuuv8gyV+sqqer6teq6k0LrVhVTwyWeXpmZubepgWAdWbRUFfVdyWZbq09c9NNm5Ocb60dSPJ/JvnHC63fWnuytXagtXZgamrqngcGgPVkKa9Rf0uSD1bVB5JMJNlRVf8kyeEkvzJY5qkkPzucEQFg/Vp0j7q19mOttQdba48k+XCS32itfV+Sf5nkvYPFvi3JHw5rSABYr+7kXd83+8kkv1BVP5LkdJLvX56RAICr7ijUrbXPJvns4PLJzL8THAAYEmcmA4COCTUAdEyoAaBjQg0AHRNqAOiYUANAx4QaADom1ADQMaEGgI4JNQB0TKgBoGNCDQAdE2oA6JhQA0DHhBoAOibUANAxoQaAjgk1AHRMqAGgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCOCTUAdEyoAaBjQg0AHRNqAOiYUANAx6q1tnJ3VvVakq+s2B2urL1JZkc9xBCs1e1KbNtqtVa3ba1uV7K2t+0trbXtw7yD8WF+8QV8pbV2YIXvc0VU1dNrcdvW6nYltm21Wqvbtla3K1n72zbs+3DoGwA6JtQA0LGVDvWTK3x/K2mtbtta3a7Etq1Wa3Xb1up2Jbbtnqzom8kAgDvj0DcAdEyoAaBjyxLqqvovq+oPqmquqg5cd/3Gqvq5qvpiVT1XVT923W1/rqq+UlVfraofvcXX3VxVvzhY5vNV9chyzLtUt9mu762qL1z3Z66q3lFV22+6fraqfnqBr/tIVZ27brmfWcntGsxwR9s2uO2zg8fs6m37bvG1f2zwmH2lqv7TFdqk6+//Th+3rVX1r6vqy4P1fvIWX3e1Pm7fNHgOfrWq/kFV1QJftwa3fbWqfr+q3rmCm3XL7Rrc9ier6v8b3P7FqppYC8+1wW3fsG2D61f1c21w20KP26p/rg1uu9XjNpznWmvtnv8k+Q+TvCXJZ5McuO76v5zknw0ub03yQpJHkmxI8rUkjyXZlOT3kvyJBb7u30zyM4PLH07yi8sx771u103LvD3J125x2zNJvnWB6x9J8uxKbstybNvtlr1umT8xeDw3J3l08Dhv6HnbBv823zu4vCnJbyb5zjX0uP1WkncnqSS/dott+8Dgthos+/ketivz53r4/SSPDz7fs9C/p9X4XLvdtq3259qttm0tPNcWedyG8lxblj3q1tpzrbWFzjjWkkxW1XiSLUkuJjmV5F1Jvtpae761djHJP0vyoQXW/1CSnxtc/uUk71voO5Rhuc12Xe8vZX7+G1TVm5Psy/w/xO7cy7Yt4kOZ/+bsQmvt60m+mvnHe8Xc6ba11s621v7d4PLFJL+T5MHhTnl37nTbqur+JDtaa59r8/9L/HySv7DAOh9K8vNt3ueS7BqsuyJus13vT/L7rbXfGyx3vLV25foFVvFzbdFtW0TPz7UFt22NPNcW3LZhPteG/Rr1Lyc5k+SlJC8m+XuttVeSPJDk0HXLHR5cd7Nry7XWLid5NfPfvfTkLyb5pwtcf/UIwK3eVv9oVf1uVf3fVfWnhzfePVlo2352cCjqf7zFN01LfWxHbcHHrap2JfnuJJ+5xXqr7XF7IPOPwVWLPtcWWW6lvTlJq6pfr6rfqaqPLrDMan2uLbZtq/m5tujjtoqfa7fatqE915Z8CtGq+rdJXrfATT/eWvvVW6z2riRXkrw+yX1JfnPwdbpxl9t1dd1vTnK2tfbsAjd/OMl/dYtVX0rycGvteFV9U5J/WVX/UWvt1J3MvpghbNv3ttaOVNX2JP8i89v388s28B0YxuM2OPLzT5P8g9ba8wusulofty7c5XaNJ3lPkj+V5GySz1TVM6216/9zX63Ptdtt22p/rt32cVvlz7UFty3zO5JDseRQt9b+zF18/b+c5JOttUtJpqvq/01yIPPfTTx03XIPJjmywPpHBssdHjywO5Mcv4s5bukut+uqD2fhvbLHk4y31p65xX1eSHJhcPmZqvpa5r9LW9Zzxi73trXWjgw+vlZVH8/8N2I3/+dx9TG76laP7T0ZxuOW+RMX/FFr7advcZ+r8XE7khsPLS72XFtsubt2l9t1OMn/01qbTZKq+jdJ3pnBXtgqf67dctvWwHPtto9bVvdz7Vbb9k8ypOfasA99v5jkO5KkqiYz/8L5l5P8dpI3VdWjVbUp8/+5fGKB9T+R5CODy/9Fkt+4zeGtFVVVY0m+Jwu/hvuXsnAIrq47VVUbBpcfS/KmJAt9VzkSC21bVY1X1d7B5Y1JvivJQnttn0jy4Zp/x/6jmd+23xr+1Etzq8etqv7nzH8j+Ldvs+6qe9xaay8lOVVV7x4cPv0rSRbaU/hEkr8yeEfqu5O8Olh31H49ydtr/t3C40m+LcmXrrt9NT/XFty2NfJcu+Xjtgaeawtu21Cfa2153h33n2X+u4wLSY4l+fXB9duS/PMkf5D5B+m/u26dDyT5w8y/U/HHr7v+J5J8cHB5YrD+VzP/D/Cx5Zj3XrdrcNu3J/ncLdZ7Pslbb7rug0l+YnD5Px/8nXwh82+m+O6V3K672bYkk5l/Z+3vD2b/WP74nY7Xtm3w+Y8PHtevZIF3PXa4bQ9m/o2Pzw0eky8k+f618LgNrj+Q+f/ov5bkf8sfn5HwB5L8wOByJfnfB8t8MYu843iFt+v7Bn/vzyb5qZvWW+3PtW/YtjX0XFto29bKc23Bf5PDeq45hSgAdMyZyQCgY0INAB0TagDomFADQMeEGgA6JtQA0DGhBoCO/f/68sCA7e628wAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 864x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Let's take a look at where this is on a world map\n",
+    "world = gpd.read_file(gpd.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, figsize=(12, 10))\n",
+    "axes.set(xlim=(-180, -160), ylim=(45, 60))\n",
+    "world.plot(ax=axes, color=\"lightgray\")\n",
+    "geodata.plot(ax=axes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f84d99d3",
+   "metadata": {},
+   "source": [
+    "Now let's pick our target date - we'll use today."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6604a4f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-02-18\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set the target date\n",
+    "target_date = datetime.datetime.today().date()\n",
+    "print(target_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27b008c2",
+   "metadata": {},
+   "source": [
+    "We'll use the following options in our query:\n",
+    "- `cell_id` set to the `cell_id` we identified above\n",
+    "- `date_forecast_for` set to our `target_date`\n",
+    "- `sortby` set to `date_forecast_generated` so that we get results in ascending order of date\n",
+    "- `limit` set to 1000 so that we get all available forecasts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1305ce1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{api_base_url}/collections/north_forecasts_historic/items?cell_id={cell_id}&date_forecast_for={target_date}&sortby=date_forecast_generated&limit=1000\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0da6378",
+   "metadata": {},
+   "source": [
+    "# Load data and plot it\n",
+    "Let's load our data into `GeoPandas` and look at it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6ec06f5e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>forecast_id</th>\n",
+       "      <th>date_forecast_generated</th>\n",
+       "      <th>date_forecast_for</th>\n",
+       "      <th>cell_id</th>\n",
+       "      <th>sea_ice_concentration_mean</th>\n",
+       "      <th>sea_ice_concentration_stddev</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POLYGON ((-169.78913 52.68087, -170.13419 52.7...</td>\n",
+       "      <td>2227117</td>\n",
+       "      <td>2022-01-03</td>\n",
+       "      <td>2022-02-18</td>\n",
+       "      <td>80840</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POLYGON ((-169.78913 52.68087, -170.13419 52.7...</td>\n",
+       "      <td>19583148</td>\n",
+       "      <td>2022-01-04</td>\n",
+       "      <td>2022-02-18</td>\n",
+       "      <td>80840</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POLYGON ((-169.78913 52.68087, -170.13419 52.7...</td>\n",
+       "      <td>36939179</td>\n",
+       "      <td>2022-01-05</td>\n",
+       "      <td>2022-02-18</td>\n",
+       "      <td>80840</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POLYGON ((-169.78913 52.68087, -170.13419 52.7...</td>\n",
+       "      <td>54295210</td>\n",
+       "      <td>2022-01-06</td>\n",
+       "      <td>2022-02-18</td>\n",
+       "      <td>80840</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POLYGON ((-169.78913 52.68087, -170.13419 52.7...</td>\n",
+       "      <td>71651241</td>\n",
+       "      <td>2022-01-07</td>\n",
+       "      <td>2022-02-18</td>\n",
+       "      <td>80840</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            geometry  forecast_id  \\\n",
+       "0  POLYGON ((-169.78913 52.68087, -170.13419 52.7...      2227117   \n",
+       "1  POLYGON ((-169.78913 52.68087, -170.13419 52.7...     19583148   \n",
+       "2  POLYGON ((-169.78913 52.68087, -170.13419 52.7...     36939179   \n",
+       "3  POLYGON ((-169.78913 52.68087, -170.13419 52.7...     54295210   \n",
+       "4  POLYGON ((-169.78913 52.68087, -170.13419 52.7...     71651241   \n",
+       "\n",
+       "  date_forecast_generated date_forecast_for  cell_id  \\\n",
+       "0              2022-01-03        2022-02-18    80840   \n",
+       "1              2022-01-04        2022-02-18    80840   \n",
+       "2              2022-01-05        2022-02-18    80840   \n",
+       "3              2022-01-06        2022-02-18    80840   \n",
+       "4              2022-01-07        2022-02-18    80840   \n",
+       "\n",
+       "   sea_ice_concentration_mean  sea_ice_concentration_stddev  \n",
+       "0                         1.0                           0.0  \n",
+       "1                         1.0                           0.0  \n",
+       "2                         1.0                           0.0  \n",
+       "3                         1.0                           0.0  \n",
+       "4                         1.0                           0.0  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Look at the first few rows of data\n",
+    "geodata = gpd.GeoDataFrame.from_features(response.json(), crs=\"EPSG:4326\")\n",
+    "geodata.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3df89bc",
+   "metadata": {},
+   "source": [
+    "And now let's plot it with `matplotlib`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cd1dadfd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAALICAYAAABijlFfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAA1DklEQVR4nO3de7SleVkf+O/TFBcdmmsXGLppmiEoMpEg1qAMWctmoWPjJJDAJFyiEydCm1lB4y2CWUgcdKJmiFkyQqRDCDqZcBl0kR5t7ETACzfp4k7TdNODaHcnSgl4YRKBht/8sXfj4VDVVb3rec/Zv9qfz1p71dnv3ud7nrfe97zv/p69zz41xggAAABn77zDHgAAAOBcoWABAAA0UbAAAACaKFgAAABNFCwAAIAmRw7rC19wwQXjkksuOawvDwAAsLF3vvOdfzjGOLp/+aEVrEsuuSTHjx8/rC8PAACwsar63ZMt9xJBAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATU5bsKrq5VX1sar6wClu/9tV9b6qen9VvbWq/nL/mAAAANvvTJ7BekWSy27n9t9J8o1jjK9J8mNJrmiYCwAAYDpHTneHMcZvVtUlt3P7W/dcfXuSixrmAgAAmE7372B9Z5LXn+rGqrq8qo5X1fETJ040f2kAAOBMPfWlb8tTX/q2rc5cYsaltRWsqnpcVgXrOae6zxjjijHGsTHGsaNHj3Z9aQAAgK1w2pcInomqekSSlyV5whjj4x2ZAAAAsznrZ7Cq6uIkv5Tk28cYN5z9SAAAAHM67TNYVfXKJJcmuaCqbk7yj5PcOUnGGD+X5PlJ7pvkJVWVJLeOMY4tNTAAAMC2OpN3EXz6aW5/ZpJntk0EAAAwqe53EQQAANhZChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmpy2YFXVy6vqY1X1gVPc/rCqeltVfbqqfrB/RAAAgDmcyTNYr0hy2e3c/okk35PkhR0DAQAAzOq0BWuM8ZtZlahT3f6xMcY1ST7bORgAAMBsDvR3sKrq8qo6XlXHT5w4cZBfGgAAYHEHWrDGGFeMMY6NMY4dPXr0IL80AADA4ryLIAAAQBMFCwAAoMmR092hql6Z5NIkF1TVzUn+cZI7J8kY4+eq6iuSHE9yjySfr6rvTfLwMcafLDU0AADANjptwRpjPP00t/9+kovaJgIAAJiUlwgCAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0OS0BauqXl5VH6uqD5zi9qqqF1XVjVX1vqp6VP+Yy/vYn/xZ/tZL35aP/emfydyyvFkyZ5hxicwZZlwic4YZZ8mcYcYlMmeYcYnMGWZcInOGGWfJnGHGJTKXmJFlnMkzWK9Ictnt3P6EJA9dXy5P8i/OfqyD96I3fDjXfPQTedGvfVjmluXNkjnDjEtkzjDjEpkzzDhL5gwzLpE5w4xLZM4w4xKZM8w4S+YMMy6RucSMLKPGGKe/U9UlSX55jPGXTnLbS5P8+hjjlevr1ye5dIzxn24v89ixY+P48eMbDd3pq573+nz61s9/yfK7Hjkv1//4E2SeYzMukTnDjEtkzjDjEpkzzDhL5gwzLpE5w4xLZM4w4xKZM8w4S+YMMy6RucSMt3nqS9+WJHn1dz3mrHKWzFxixi5V9c4xxrH9yzt+B+vCJDftuX7zetnJhri8qo5X1fETJ040fOmz91s/9Lg88ZEPyN3uvPqvuNudz8uTHvmA/NZzHifzHJxxicwZZlwic4YZl8icYcZZMmeYcYnMGWZcInOGGZfInGHGWTJnmHGJzCVmZFkH+iYXY4wrxhjHxhjHjh49epBf+pTud4+75fy7Hsmnb/187nrkvHz61s/n/Lseyf3Ov5vMc3DGJTJnmHGJzBlmXCJzhhlnyZxhxiUyZ5hxicwZZlwic4YZZ8mcYcYlMpeYkWUdaci4JckD91y/aL1sGn/4qU/nb3/9g/KMR1+cf/uO38uJhl8e3NXMGWZcInOGGZfInGHGJTJnmHGWzBlmXCJzhhmXyJxhxiUyZ5hxlswZZlwic4kZWU7H72D9D0meneRbk3x9kheNMR59usxt+R0sAADYRX4H6+yc6newTvsMVlW9MsmlSS6oqpuT/OMkd06SMcbPJbkqq3J1Y5L/nOR/7hsbAABgHqctWGOMp5/m9pHk77dNBAAAMKkDfZMLAACAc5mCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmZ1Swquqyqrq+qm6squee5PYHVdUbqup9VfXrVXVR/6gAAADb7bQFq6rulOTFSZ6Q5OFJnl5VD993txcm+YUxxiOSvCDJT3QPCgAAsO3O5BmsRye5cYzxkTHGZ5K8KsmT9t3n4UneuP74TSe5HQAA4Jx3JgXrwiQ37bl+83rZXu9N8uT1x38jyflVdd/9QVV1eVUdr6rjJ06c2GReAACArdX1Jhc/mOQbq+rdSb4xyS1JPrf/TmOMK8YYx8YYx44ePdr0pQEAALbDkTO4zy1JHrjn+kXrZV8wxviPWT+DVVV3T/KUMcYfNc0IAAAwhTN5BuuaJA+tqgdX1V2SPC3JlXvvUFUXVNVtWT+c5OW9YwIAAGy/0xasMcatSZ6d5Ook1yV5zRjj2qp6QVU9cX23S5NcX1U3JLl/kv9toXkBAAC21pm8RDBjjKuSXLVv2fP3fPzaJK/tHQ0AAGAuXW9yAQAAsPMULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0OaOCVVWXVdX1VXVjVT33JLdfXFVvqqp3V9X7qupb+0cFAAC6fObWz+eD//FP8rE//bOtzVxixqWdtmBV1Z2SvDjJE5I8PMnTq+rh++72vCSvGWN8bZKnJXlJ96AAAECfW/7ov+RPP31rXvRrH97azCVmXFqNMW7/DlWPSfKjY4xvWV//4SQZY/zEnvu8NMlHxhg/tb7/Pxtj/He3l3vs2LFx/Pjxs50fAAC4A77qea/Pp2/9/Jcsv+uR83L9jz9hKzKXmLFbVb1zjHFs//IzeYnghUlu2nP95vWyvX40ybdV1c1Jrkry3acY4vKqOl5Vx0+cOHFGgwMAAH1+64celyc+8gE5r1bX73bn8/KkRz4gv/Wcx21N5hIzHpSuN7l4epJXjDEuSvKtSf7PqvqS7DHGFWOMY2OMY0ePHm360gAAwJm63z3ulvPveiSfH0lV8ulbP5/z73ok9zv/bluTucSMB+XIGdznliQP3HP9ovWyvb4zyWVJMsZ4W1XdLckFST7WMSQAANDnDz/16dzv/LvmfuffNY+8+N450fAmEt2ZS8x4EM7kd7COJLkhyeOzKlbXJHnGGOPaPfd5fZJXjzFeUVVfneQNSS4ctxPud7AAAODwPPWlb0uSvPq7HrO1mUvM2GXj38EaY9ya5NlJrk5yXVbvFnhtVb2gqp64vtsPJHlWVb03ySuTfMftlSsAAIBz0Zm8RDBjjKuyevOKvcuev+fjDyZ5bO9oAAAAc+l6kwsAAICdp2ABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoMkZFayquqyqrq+qG6vquSe5/Z9X1XvWlxuq6o/aJwUAANhyR053h6q6U5IXJ/nmJDcnuaaqrhxjfPC2+4wxvm/P/b87ydcuMCsAAMBWO5NnsB6d5MYxxkfGGJ9J8qokT7qd+z89ySs7hgMAAJjJmRSsC5PctOf6zetlX6KqHpTkwUneeIrbL6+q41V1/MSJE3d0VgAAgK3W/SYXT0vy2jHG50524xjjijHGsTHGsaNHjzZ/aQAAgMN1JgXrliQP3HP9ovWyk3lavDwQAADYUWdSsK5J8tCqenBV3SWrEnXl/jtV1cOS3DvJ23pHBAAAmMNpC9YY49Ykz05ydZLrkrxmjHFtVb2gqp64565PS/KqMcZYZlQAAIDtdtq3aU+SMcZVSa7at+z5+67/aN9YAAAA8+l+kwsAAICdpWABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoMkZFayquqyqrq+qG6vquae4z9+qqg9W1bVV9W97xwQAANh+R053h6q6U5IXJ/nmJDcnuaaqrhxjfHDPfR6a5IeTPHaM8cmqut9SAwMAAGyrM3kG69FJbhxjfGSM8Zkkr0rypH33eVaSF48xPpkkY4yP9Y4JAACw/c6kYF2Y5KY9129eL9vrK5N8ZVW9pareXlWXnSyoqi6vquNVdfzEiRObTQwAALClut7k4kiShya5NMnTk/zLqrrX/juNMa4YYxwbYxw7evRo05cGAADYDmdSsG5J8sA91y9aL9vr5iRXjjE+O8b4nSQ3ZFW4AAAAdsaZFKxrkjy0qh5cVXdJ8rQkV+67z+uyevYqVXVBVi8Z/EjfmAAAANvvtAVrjHFrkmcnuTrJdUleM8a4tqpeUFVPXN/t6iQfr6oPJnlTkn84xvj4UkMDAABso9O+TXuSjDGuSnLVvmXP3/PxSPL96wsAAMBO6nqTCwAAgJ2nYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgyRkVrKq6rKqur6obq+q5J7n9O6rqRFW9Z315Zv+oAAAA2+3I6e5QVXdK8uIk35zk5iTXVNWVY4wP7rvrq8cYz15gRgAAgCmcyTNYj05y4xjjI2OMzyR5VZInLTsWAADAfM6kYF2Y5KY9129eL9vvKVX1vqp6bVU98GRBVXV5VR2vquMnTpzYYFwAAIDt1fUmF/9PkkvGGI9I8h+S/PzJ7jTGuGKMcWyMcezo0aNNXxoAAGA7nEnBuiXJ3mekLlov+4IxxsfHGJ9eX31Zkq/rGQ8AAGAeZ1Kwrkny0Kp6cFXdJcnTkly59w5V9Rf2XH1ikuv6RgQAAJjDad9FcIxxa1U9O8nVSe6U5OVjjGur6gVJjo8xrkzyPVX1xCS3JvlEku9YcGYAAICtdNqClSRjjKuSXLVv2fP3fPzDSX64dzQAAIC5dL3JBQAAwM5TsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGiiYAEAADRRsAAAAJooWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQ5IwKVlVdVlXXV9WNVfXc27nfU6pqVNWxvhEBAADmcNqCVVV3SvLiJE9I8vAkT6+qh5/kfucn+QdJfrt7SAAAgBmcyTNYj05y4xjjI2OMzyR5VZInneR+P5bkp5L8WeN8AAAA0zhyBve5MMlNe67fnOTr996hqh6V5IFjjF+pqn94qqCqujzJ5Uly8cUX3/FpAQCAFq/+rsdsfeYSMy7trN/koqrOS/LTSX7gdPcdY1wxxjg2xjh29OjRs/3SAAAAW+VMCtYtSR645/pF62W3OT/JX0ry61X10STfkORKb3QBAADsmjMpWNckeWhVPbiq7pLkaUmuvO3GMcYfjzEuGGNcMsa4JMnbkzxxjHF8kYkBAAC21GkL1hjj1iTPTnJ1kuuSvGaMcW1VvaCqnrj0gAAAALM4kze5yBjjqiRX7Vv2/FPc99KzHwsAAGA+Z/0mFwAAAKwoWAAAAE0ULAAAgCYKFgAAQBMFCwAAoImCBQAA0ETBAgAAaKJgAQAANFGwAAAAmihYAAAATRQsAACAJgoWAABAEwULAACgiYIFAADQRMECAABoomABAAA0UbAAAACaKFgAAABNFCwAAIAmChYAAEATBQsAAKCJggUAANBEwQIAAGhSY4zD+cJVJ5L87qF88VO7IMkfytzKvFkyZ5hxicwZZlwic4YZZ8mcYcYlMmeYcYnMGWZcInOGGWfJnGHGJTJnmHGJzCVm7PCgMcbR/QsPrWBto6o6PsY4JnP78mbJnGHGJTJnmHGJzBlmnCVzhhmXyJxhxiUyZ5hxicwZZpwlc4YZl8icYcYlMpeYcUleIggAANBEwQIAAGiiYH2xK2Rubd4smTPMuETmDDMukTnDjLNkzjDjEpkzzLhE5gwzLpE5w4yzZM4w4xKZM8y4ROYSMy7G72ABAAA08QwWAABAEwULAACgiYIFAADQRMFaWFU96rBnuD1VdY+q+rqquvdhz3I6VXVBU869q+oeHVnrvPtX1aPWl/t35XJ2qurIno/vXlXHquo+hznTqdiHkiW2TVU9sTtzF8z0vZOs9p1tno/tfyyUzPN4qOuxEMva2YJVVQ+rqtdX1a9U1UOq6hVV9UdV9Y6q+uoNMx+17/J1Sa6sqq/d9OBSVX93z8cXVdUb1nO+taq+coO8f3PbN2dVfUuSDyT5qSTvqaq/ueGMn6iql1XV46uqNsk4SeYTqup3qurN6/+/a5P8dlXdXFWP3yDvAVX1C1X1x1n9JfAPVNXvVdWPVtWdN5zxkVX19iS/nuSfri+/UVVvX+JkUlV3787sUFV/saqeUlUPP4uMezWOlKr6jiR/UFU3VNUTkrwvq/38vVX19LPMPrreJx9xtttkV/ehqnpsVV1XVddW1ddX1X9Ick1V3VRVj9kw88n7Lk9JcsVt15vmbn0Q73vnrLIurqpXVdWJJL+d5B1V9bH1skvOJvskX+v9nXlnk1lVD1yv429V1T/ae/6qqtdtmNn6eGiGx0LrnNbHQzM8Frqdr9N2bNvG49qhGGPs5CXJbyb5a0menuR3kzwtSa2XvWHDzM8neWuSN+25/Jf1v2/cMPNdez5+TZLLsyrGf2OTOZO8f8/Hb01yyfrjC5K8d8MZr0/y7CRvSXJLkp9J8g1nuX3ek+Srkzwmycdvy1sve9cGeW9Mcun64ycn+edJ/qskP57kirOY8etPsvwbNv2/PM3X+70NPudrkrw9yU1ZvcXpvffc9o4N53hTkgvWH397khuSvCzJ+5N894aZtyb5tSTfmeReDf9X71/v0w9O8idJHrJefv8k79sw8+HrGW9M8pmsHtT9TpJXJLmnfegOZb5jnfuYrH7g8VfWyx+V5C0bZn42yS8neXmSf72+/On635dvkPe8fdv+hvX2/ujJttkZZvre6fveeVuSpya5055ld8rqXP72DfKefIrLU5Kc2HDGJTL/Q5K/l+SRSf6PrM7j913f9u4NM1sfD2WCx0K37et7Pj7rx0OZ4LHQ+nNbj22Z4Lh2GJdDH+DQVnzPgSjJjftu23SnfUqS30jyhD3Lfucs59x7UHnPqdbhDuRdm+Qe64/fnOS8vbc1zHhxkh9K8q4kH0nyTxoyb9p323s2yHvvvuvv3PPxhzac8cO3c9uNG2Z+/ykuP5DkExvkvTnJZUnuleQH19v/tgdMd3j/WX/eB/Z8fE3+/OT+5dn8Adj7k/zVJP/X+iTy77I6yX/Zhnnv2fPxf9x326Yzvj3JV60/fnSSn19//Kwkr7UP3aHMd+/5+Lp9t216/P1vk7whyf+yZ9nvbJK1f44kv5L1cX297d+6YabvnYP53jnlbbfzOZ/NqvD965Nc/nTDGZfIfM++69922/fkWXzvvHvPx2f9eCgTPBZaf17r46FM8FjoJJlnfWyb4bh2GJcvvM56B91pz8c/ve+2u2wSOMb4xaq6OsmPrZ/O/oEkY8P5bnNRVb0oq58mHa2qO48xPru+bZOXtv2vSd5UVS/O6qcs/3dVXZnkcUl+dcMZv/BU+Bjj97J+qVNVPSyrnzBu4o+q6ruS3CPJJ6vq+7L6qdU3JfnUBnknqurbsvpJy5Oz+klN1k/jb/pS2ddX1a8k+YWsfrqfJA9M8j9l8//Lf5Lkf8/qpzf7bTLn+WOM22Z5YVW9M8mvVtW3Z/N987NVdeEY45astsX/t17+6Xzx99Udyhxj/HKSX66qL8vqJ6dPS/Liqrp6jPGMO5j3e1X1E0nOT/KhqvpnSX4pq/3nP20445eNMa5PkjHGO6rq59Yf/8uq+v4NM3d1H9o7xw/vu23T4+81VfXNSb67qt6U5DlnMd9+DxhjvH79dd6x3kc34Xun73vnnVX1kiQ/ny/+3vk7Sd69Qd77krxwjPGB/TdU1TdtOOMSmXeuqruNMf4sScYY/6aqfj/J1Vm9KmMTrY+HJnkslPQ/HprhsdB+Hce2GY5rB26XC9aLq+ruY4xPjTFectvCqvqLWT0tuZExxqeSfN/6dcY/n9VJ6mz8wz0fH09y96y+yb4iyZUbzPeaqnp3kmcm+cqs9oFvSPLKMcbVG874plN8rQ9ldQDbxN9J8rysDsr/fVYvXbg6q5cvPGuDvL+b5IVJnpvVU+7PXi+/T770Ad4ZGWN8z/p3FJ6U5ML14luSvHiMcdUmmVn9tOt1Y4x37r+hqp65SWBV3XOM8cfrmd9Uq99N+cWs1n0T35fk31fVL2b1E8A3rk+mfyWrn8xuNOZtH4wx/ktWJ5DXVNU9k/z1DfK+LcnfT/LHWW3zb8lqO/9uku/YcMb/t6p+JKuXmz45q/0o69+B2Kik7/A+9CNV9eVjjP88xnjdnq/zkKzK5kbGGJ9P8jNV9dqsXgZ8Nv7r9YOtyurB3ZePMf7z+rZNH9D53mn63snqhxDfmdU5Zu/3zpVJ/tUGed+b1UsiT+ZvbJC3VObLknx9Vs8QJUnGGL+2/p2hf7phZvvjoW1/LLSesfvx0AyPhZL+Y9sMx7UDV+un4ljA+tmR88cYpzrAwhepqq9K8vExxh+e5Lb7jzH+4A7mPSPJR8YYb9+3/OIkPzLG2OgAvT7IPSN/flK6Ocm/W59INsn7wTHGCzf53IOy/qXbf5TVa9bfm+Qnxxh/uv6/+Or9/8eHZb0PfWKMceIkt23NPrTtquob9y165xjjU7V6l8f/cYzx4g1zfe9s6fcOy/BYaLsscWzbxePa6exswarV29B+Z1Y/RXrAevEtWb3O81/teep5WzL/er74p3QbZXbn7cs8iPV+XVa/sH7o632ar3fFGOPyzkx6bNO2qao7ZfXT04uSvH6M8dY9tz1vjPHjhzbcgvat96+OMd6y57aN1nuJzF00y/9jVX15Vq9EGFm92cNTs/rdnw8lecH6GZSzyXtaVs+2bZS3zpztcUZL5gyPhZbInOGxEAdnlwvWK5P8UVZPXd+8XnxRVk/H3meMcYdfLztD5gwzLpG50IynenlUZfWmGhfd0czTfL3WYrBE0diWzFm2TVW9LKtfBH5HVu++9BtjjO9f3/auMcYdfkvj7gfIC5WhJda7NfMASmBLoV5gey+9T3at92uy+t2rL0vyVUmuS/LqJE9M8hVjjG8/zLx15tafG5fInGHGJTJnmPEMvt5OPs5Ywi4XrBvGGCf92wm3d9vsmTPMuETmQjN+LqvXQe/9exdjff3CMcYd/uXg7mKwRNGYIXOGbbPOfN8Y4xHrj48keUlWbxH89KzeavprN8jsLhpLPOBeYr1bM2cogUtkzrBPrj/vPWOMR65ffvafkvyFMcZYX3/vbetwWHnrzK0/Ny6ROcOMS2TOMOP683byccZB2+U3ufhErX4p9BfH6hejU1XnJfmbST55DmfOMOMSmUvM+JEkjx+rdwv6IlV100nufyZO5NTF4H5bkDdL5gzbJtnzDl1jjFuTXF5Vz8/qzQA2/UOsj97zAPlnk7ykqn4pqwfIdbufeTB5yTLr3Z25xHrPkDnDPvkF6xJ01Vj/tHh9feOfHDfnzXBuXCJzhhmXyJxhxmR3H2ccrLEF7xV/GJckl2T19P+JrP4o2g3rj1+d5MHnauYMM0603n8/yV8+xW2b/nG9Dye5+BS33XTYebNkzrBt1p/3b5JcdpLlz8zqbWo3yfySv+uW5PlZvQ3xJn8fqDVvwfVuzVxovbc+c4Z9cv35L0ty95Msf0iSNx923vpzlzjvbH3mDDPu+Hrv5OOMg74c+gDbcEly36z/MNouZc4w4yzr3ThbazHozpspc9u3zYJzdheN9gfcM1yWWO9ZMmf4vzzN16tty5vh3LhE5gwz7tp67+rjjIO+7OzvYJ3MLL+Mt6u/hLir602PWbbNLHN28/24vWb5f9zVc8QMmTPMuETmDDOyjE3/wN+56tiOZs4w4xKZM8yYqrpim/Mmytz6bbO29XPOst7dmZPs5753tjdvlzNnmHGJzBlmnOIcsdAxYzEK1hf72I5mzjDjEpkzzJjs6AF/gcwZtk0yx5yzrHd35gz7+RKZM+yTye6eI2bInGHGJTJnmDGZ4xyxROZiFKw9xhiX7WLmDDMukTnDjGu7esBvzZxk28wy5xTrvUDm1u/nS2ROsk/u7DlihswZZlwic4YZ17b+HLFQ5mIUrJOY5anNXX1Kd9fWe1cP+AudRLZ62+y1zXPOst7dmbPs5753tuMcUVV3qqrvqqofq6rH7rvteedq5gwzLpE5w4ynMsM5YsljxhJ2tmBV1X1Ocblvkm89VzNnmHGJzBlmPIOvtxUPGmbInGXbzDJnd97s34/bsp8vkTnLPjnDOSLJS5N8Y5KPJ3lRVf30ntuefA5nzjDjEpkzzKhYHpCdfRfBqvpcTv1HzC4cY9zlpJ84eeYMMy6ROcOM68yd/AvrC6z31m+bWeacaL27jxlbv58vkTnDPrnEnAut9/vGn/+B5SNJXpLkgqz+wPLbxxhfey5mzjDjEpkzzLjOeVmSL0/yjiTfnuQ3xhjfv77tXWOMRx1m3lKZB+3IYQ9wiD6S5PFjjN/bf0NV3XQOZ84w4xKZM8yY7O5fWO/OnGHbJHPMOct6d2fOsJ8vkTnDPpnMcY74QikbY9ya5PKqen6SNya5+zmcOcOMS2TOMGOSPHpPafvZJC+pql/KqrTV7X7mweQtlXmwxhb8Ma7DuGSSP4zWnTnDjDu+3jv5F9YXWO+t3zazzDnRencfM7Z+P19oe2/9PrnQ9l5ivaf4w9LdmTPMuOPr/aGTLHt+krck+fBh5y2VedCXQx/AxcXlzy+TPGiYInPbt80sc86y3tv+/zhT5gz/ly4uLptddrVYHvRlZ38HK0mq6mFJnpTkwvWiW5JcOca47lzOnGHGJTJnmJE+s2ybWebs5vtxe83y/7ir54gZMmeYcYnMGWbkYOxswaqq52T1Ws5XJbl5vfiiJE9L8qoxxk+ei5kzzLhE5gwz7sndyQN+Z+ZE22aWObd+vRfK3Or9fInMifbJnTxHzJA5w4xLZM4w457crT5HLJV5kHa5YN2Q5L8ZY3x23/K7JLl2jPHQczFzhhmXyJxhxvXn7uQBf4H13vptM8ucE6139zFj6/fzJTJn2CeXmHOGfXKWzBlmXCJzhhnXnzvDOWKRYnmgTva6wV24JPlQkgedZPmDklx/rmbOMOOOr/cNSe58kuV3yWa/fNqaN0vmDNtmljknWu/uY8bW7+cLbe+t3ycX2t5bv0/OkjnDjDu+3jOcI9ozD/qyy2/T/r1J3lBVH05y21uwXpzkLyZ59jmcOcOMS2TOMGOSfD7JA7J6S+O9/sL6tsPOmyXze7P92yaZY85Z1rs7c4b9fInM783275PJ7p4jZsicYcYlMmeYMZnjHLFE5oHa2ZcIJklVnZfk0fni13deM8b43LmcOcOMS2ROMuNlSX42q7c1/pKD6RjjVw8zb7LMrd42s8w5y3p3Z060n/ve2aFzxCyZM8y4ROYkM279OWKpY8ZB2umCtV9VXT7GuGLXMmeYcYnMbZ1xFw/4S2Xuy9+6bXOKr7F1c86y3t2Zs+znvne+8DV24hwxY+YMMy6Rua0zznCOOIhjxqIO+zWK23RJ8q5dzJxhxh1f78u3OW+WzBm2zSxzTrTe3ceMrd/PF9reW79PLrS9t36fnCVzhhl3fL1nOEe0Zy55OW/TYnaOqh3NnGHGJTJnmDFJ/t6W582SOcO2SeaYc5b17s6cYT9fInOGfTLZ3XPEDJkzzLhE5gwzJnOcI5bIXIyC9cX+2o5mzjDjEpkzzJjs7gG/O3OGbZPMMecs692dOcN+vkTmDPtksrvniBkyZ5hxicwZZkzmOEcskbmYnS5YVfWwqnp8Vd09ScYYN6+XX3YuZ84w4xKZM8x4Crt6wD+rzFm2zSxzdudN+v24dfv5Epmz7JO7eo6YIXOGGZfInGHGU9i6c8QBZS7nsF+jeFiXJN+T5Pokr0vy0SRP2nPbRq9vnSFzhhl3eb3Xn/uwJI9Pcvd9yy/bhrwZMifaNrPMufXrvVDmVu/nS2ROtE/u5DlihswZZtzl9V5/7lafI5bKPMjLoQ9waCuevP+2jZbkkiTHk/yD9fV3n6uZM8y44+u9kwf8BdZ767fNLHNOtN7dx4yt388X2t5bv08utL23fp+cJXOGGXd8vWc4RyxSLA/ysst/aPi8McankmSM8dGqujTJa6vqQdn8dZ4zZM4w4xKZM8yYJM9K8nVjjE9V1SXrvEvGGD+zYWZ33iyZM2ybWeacZb27M2fYz5fInGGfXGLOGfbJWTJnmHGJzBlmTOY4RyyReaB2+Xew/qCqHnnblfUO/FeTXJDka87hzBlmXCJzhhmTfQfTJJcmeUJV/XQaDvgNebNkzrBtZplzlvXuzpxhP18ic4Z9cok5Z9gnZ8mcYcYlMmeYMZnjHLFE5sEah/wU2mFdklyU5CtOcdtjz9XMGWbc8fV+Y5JH7lt2JMkvJPncYefNkjnDtpllzonWu/uYsfX7+ULbe+v3yYW299bvk7NkzjDjjq/3DOeI9syDvtR6aGALVNVFSW4dY/z+SW577BjjLYeZN1NmtxlmTObYh2Ywy34+w/aZYUbYFTOcI86FY8bOvkSwqr6mqt5eVTdV1RVVde89t73jXM2cYcYlMmeYMVm9/erJDijr2+7wAaU7b5bMGbbNLHPOst7dmTPs50tkzrBPLjHnDPvkLJkzzLhE5gwzJnOcI5bIPGg7W7CS/IskP5rVa1hvSPLmqnrI+rY7n8OZM8y4ROYMM+7sAX+BzK3fNrPMOct6d2dOsp/73tmxc8QkmTPMuETmDDNOcY5Y6JhxsA77NYqHdUny3n3XH5fkw0m+IZu/reTWZ84w446v95uTXJbkXkl+MMm1SR6yvu3dh503S+YM22aWOSda7+5jxtbv5wtt763fJxfa3lu/T86SOcOMO77eM5wj2jMP+nLoAxzaiifvTXLPfcsesd5xP36uZs4w466v977ru3LAb1/vbd82s8w503p3HzOWWO9tz5xhn1xqe2/7PjlL5gwz7vp677u+leeI7syDvhz6AIe24skzknzDSZZfnORfnquZM8y44+u9swf85vXe+m0zy5wTrXf3MWPr9/OFtvfW75MLbe+t3ydnyZxhxh1f7xnOEe2ZB33xLoKwRarqGUk+MsZ4+77lFyf5kTHGsw4zb6bMbjPMmMyxD81glv18hu0zw4ywK2Y4R5wTx4zDbniHdUlyzyQ/meRDST6R5ONJrlsvu9e5mjnDjLu83i49l1m2zSxzzrDeu/p/OcO2mWHOWfbJGTJnmHGX19vlYC67/C6Cr0nyySSXjjHuM8a4b1av8fzk+rZzNXOGGZfInGHGVNU9q+onq+pDVfWJqvp4VV23Xnavw86bKHPrt80sc86y3t2Zk+znvnd27BwxSeYMMy6ROcOMU5wjFjpmHKzDbniHdUly/Sa3zZ45w4w7vt5XJ3lO9vzl9iRfsV727w87b5bMGbbNLHNOtN7dx4yt388X2t5bv08utL23fp+cJXOGGXd8vWc4R7RnHvTl0Ac4tBVP/n2SH0py/z3L7r/eeL92rmbOMOOOr/euHvC713vrt80sc0603t3HjK3fzxfa3lu/Ty60vbd+n5wlc4YZd3y9ZzhHtGce9GWXXyL41CT3TfIbVfXJqvpEkl9Pcp8kf+sczpxhxiUyZ5gxSX63qn6oqu5/24Kqun9VPSfJTVuQN0vmDNtmljlnWe/uzBn28yUyZ9gnl5hzhn1ylswZZlwic4YZkznOEUtkHqzDbniHeUnysCTflOTu+5Zfdi5nzjDjrq53knsn+amsfqH1k1n9Uut162X3Oey8yTK3etvMMucs692dOdF+7ntnh84Rs2TOMOOurnf39+Msx7WDvhz6AIe24sn3JLk+yeuSfDTJk/bctukfRtv6zBlm3OX1Xn/uzh3wuzMn2jazzLn1671Q5lbv50tkTrRP7uQ5YobMGWbc5fVef+5WnyOWyjzIy6EPcGgrnrz/to2W5JIkx5P8g/X1d5+rmTPMuOPrvZMH/AXWe+u3zSxzTrTe3ceMrd/PF9reW79PLrS9t36fnCVzhhl3fL1nOEcsUiwP8nIku+u8McankmSM8dGqujTJa6vqQUnqHM6cYcYlMmeYMUmeleTrxhifqqpL1nmXjDF+ZsPM7rxZMmfYNrPMOct6d2fOsJ8vkTnDPrnEnDPsk7NkzjDjEpkzzJjMcY5YIvNA7fKbXPxBVT3ytivrHfivJrkgydecw5kzzLhE5gwzJvsOpkkuTfKEqvrpNBzwG/JmyZxh28wy5yzr3Z05w36+ROYM++QSc86wT86SOcOMS2TOMGMyxzliicyDNQ75KbTDuiS5KHveX3/fbY89VzNnmHHH1/uNSR65b9mRJL+Q5HOHnTdL5gzbZpY5J1rv7mPG1u/nC23vrd8nF9reW79PzpI5w4w7vt4znCPaMw/6UuuhgS1QVRcluXWM8fsnue2xY4y3HGbeTJndZpgxmWMfmsEs+/kM22eGGWFXzHCOOBeOGQoWAABAk13+HSwAAIBWChYAAEATBQsAAKCJggUAANDk/wcfRb4I6QVQSwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 864x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot the data\n",
+    "fig, axes = plt.subplots(1, figsize=(12,10))\n",
+    "plt.errorbar(\n",
+    "    geodata[\"date_forecast_generated\"],\n",
+    "    geodata[\"sea_ice_concentration_mean\"],\n",
+    "    yerr=geodata[\"sea_ice_concentration_stddev\"],\n",
+    "    marker=\"*\",\n",
+    "    linestyle=\"None\"\n",
+    ")\n",
+    "plt.xticks(rotation=90)\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "731b27f9",
+   "metadata": {},
+   "source": [
+    "You have now succesfully retrieved historic `IceNet` forecasts from our API and plotted them. 🎉"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/geoapi/api-usage-latest-forecasts.ipynb
+++ b/geoapi/api-usage-latest-forecasts.ipynb
@@ -1,0 +1,964 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b934ccab",
+   "metadata": {},
+   "source": [
+    "# Using the IceNet API for the latest forecasts\n",
+    "This notebook will explain how to retrieve `IceNet` data from the public API and display it locally.\n",
+    "\n",
+    "The forecasts are made on the central part (432x432) of the 720x720 [EASE2 5km grid](https://nsidc.org/ease/ease-grid-projection-gt) projections.\n",
+    "This means that the northern hemisphere uses the [EPSG:6931](https://epsg.io/6931) projection and the southern hemisphere uses [EPSG:6932](https://epsg.io/6932)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "428ae2c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required modules\n",
+    "import datetime\n",
+    "import requests\n",
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "from shapely.geometry import Point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ec7ed287",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the base URL for API requests\n",
+    "api_base_url = \"https://app-icenetgeoapi-pygeoapi.azurewebsites.net/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "615c5014",
+   "metadata": {},
+   "source": [
+    "## Finding available datasets\n",
+    "In order to see which datasets are available we need to call the `collections` endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b54ea877",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "north_cells; Geometric grid cells (north); Northern hemisphere geometric grid cells\n",
+      "south_cells; Geometric grid cells (south); Southern hemisphere geometric grid cells\n",
+      "north_forecasts_latest; Latest forecasts (north); Most recent set of northern hemisphere sea ice concentration forecasts\n",
+      "south_forecasts_latest; Latest forecasts (south); Most recent set of southern hemisphere sea ice concentration forecasts\n",
+      "north_forecasts_historic; All forecasts (north); Historic northern hemisphere sea ice concentration forecasts\n",
+      "south_forecasts_historic; All forecasts (south); Historic southern hemisphere sea ice concentration forecasts\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Find out which collections are available\n",
+    "response = requests.get(f\"{api_base_url}/collections\")\n",
+    "collections = response.json()[\"collections\"]\n",
+    "for collection in collections:\n",
+    "    print(f\"{collection['id']}; {collection['title']}; {collection['description']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fd74070",
+   "metadata": {},
+   "source": [
+    "We can see that there are currently six collections available\n",
+    "- Northern hemisphere cells (`north_cells`): the EPSG:6931 grid geometries\n",
+    "- Southern hemisphere cells (`south_cells`): the EPSG:6932 grid geometries\n",
+    "- Northern hemisphere latest forecasts (`north_forecasts_latest`): latest sea ice concentration forecasts from the IceNet algorithm\n",
+    "- Southern hemisphere latest forecasts (`south_forecasts_latest`): latest sea ice concentration forecasts from the IceNet algorithm\n",
+    "- Northern hemisphere historic forecasts (`north_forecasts_historic`): sea ice concentration forecasts from older versions of the IceNet algorithm\n",
+    "- Southern hemisphere historic forecasts (`south_forecasts_historic`): sea ice concentration forecasts from older versions of the IceNet algorithm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adb4d342",
+   "metadata": {},
+   "source": [
+    "## Find dataset attributes\n",
+    "The available attributes of the dataset can be found by calling the `queryables` endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ea52331f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'geometry': {'$ref': 'https://geojson.org/schema/Geometry.json'},\n",
+       " 'forecast_id': {'title': 'forecast_id', 'type': 'int8'},\n",
+       " 'date_forecast_generated': {'title': 'date_forecast_generated',\n",
+       "  'type': 'date'},\n",
+       " 'date_forecast_for': {'title': 'date_forecast_for', 'type': 'date'},\n",
+       " 'cell_id': {'title': 'cell_id', 'type': 'int4'},\n",
+       " 'sea_ice_concentration_mean': {'title': 'sea_ice_concentration_mean',\n",
+       "  'type': 'float4'},\n",
+       " 'sea_ice_concentration_stddev': {'title': 'sea_ice_concentration_stddev',\n",
+       "  'type': 'float4'}}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find the list of queryables for northern hemisphere forecasts\n",
+    "response = requests.get(f\"{api_base_url}/collections/north_forecasts_latest/queryables\")\n",
+    "response.json()[\"properties\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff6d28f3",
+   "metadata": {},
+   "source": [
+    "and here we can see the available columns that will be retrieved when a query is made\n",
+    "\n",
+    "- `geometry` (the geometric shape for which the forecast was made)\n",
+    "- `forecast_id` (the ID of the forecast - only relevant for ensuring there are no duplicates)\n",
+    "- `date_forecast_generated` (the date when the forecast was made)\n",
+    "- `date_forecast_for` (which date the forecast was made for)\n",
+    "- `sea_ice_concentration_mean` (the mean of the IceNet forecast)\n",
+    "- `sea_ice_concentration_stddev` (the standard deviation of the IceNet forecast)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d9b35b3",
+   "metadata": {},
+   "source": [
+    "## Retrieving data\n",
+    "In order to retrieve one or more forecasts from the API we need to call the `items` endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d977ca73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the latest available forecasts (limited to first 10 by default)\n",
+    "response = requests.get(f\"{api_base_url}/collections/north_forecasts_latest/items\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "85d8af89",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-135, 16.4247079225175],\n",
+       "     [-135.132936604874, 16.623695732259],\n",
+       "     [-135, 16.8228850033408],\n",
+       "     [-134.867063395126, 16.623695732259],\n",
+       "     [-135, 16.4247079225175]]]},\n",
+       "  'properties': {'forecast_id': 1,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 1,\n",
+       "   'sea_ice_concentration_mean': 0.199749,\n",
+       "   'sea_ice_concentration_stddev': 0.398392},\n",
+       "  'id': 1},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.867063395126, 16.623695732259],\n",
+       "     [-135, 16.8228850033408],\n",
+       "     [-134.866443646294, 17.0213529826143],\n",
+       "     [-134.733509923942, 16.8219602213448],\n",
+       "     [-134.867063395126, 16.623695732259]]]},\n",
+       "  'properties': {'forecast_id': 2,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 2,\n",
+       "   'sea_ice_concentration_mean': 0.597203,\n",
+       "   'sea_ice_concentration_stddev': 0.482956},\n",
+       "  'id': 2},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.733509923942, 16.8219602213448],\n",
+       "     [-134.866443646294, 17.0213529826143],\n",
+       "     [-134.732264661298, 17.2190997847523],\n",
+       "     [-134.599336744208, 17.0195015207504],\n",
+       "     [-134.733509923942, 16.8219602213448]]]},\n",
+       "  'properties': {'forecast_id': 3,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 3,\n",
+       "   'sea_ice_concentration_mean': 0.583471,\n",
+       "   'sea_ice_concentration_stddev': 0.477356},\n",
+       "  'id': 3},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.599336744208, 17.0195015207504],\n",
+       "     [-134.732264661298, 17.2190997847523],\n",
+       "     [-134.597460162933, 17.4161254802106],\n",
+       "     [-134.464541014435, 17.2163197172454],\n",
+       "     [-134.599336744208, 17.0195015207504]]]},\n",
+       "  'properties': {'forecast_id': 4,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 4,\n",
+       "   'sea_ice_concentration_mean': 0.594226,\n",
+       "   'sea_ice_concentration_stddev': 0.485255},\n",
+       "  'id': 4},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.464541014435, 17.2163197172454],\n",
+       "     [-134.597460162933, 17.4161254802106],\n",
+       "     [-134.462027269888, 17.6124300955132],\n",
+       "     [-134.329119894272, 17.4124148536856],\n",
+       "     [-134.464541014435, 17.2163197172454]]]},\n",
+       "  'properties': {'forecast_id': 5,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 5,\n",
+       "   'sea_ice_concentration_mean': 0.594962,\n",
+       "   'sea_ice_concentration_stddev': 0.485845},\n",
+       "  'id': 5},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.329119894272, 17.4124148536856],\n",
+       "     [-134.462027269888, 17.6124300955132],\n",
+       "     [-134.325963102016, 17.8080136135322],\n",
+       "     [-134.193070544898, 17.6077869292982],\n",
+       "     [-134.329119894272, 17.4124148536856]]]},\n",
+       "  'properties': {'forecast_id': 6,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 6,\n",
+       "   'sea_ice_concentration_mean': 0.594645,\n",
+       "   'sea_ice_concentration_stddev': 0.485616},\n",
+       "  'id': 6},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.193070544898, 17.6077869292982],\n",
+       "     [-134.325963102016, 17.8080136135322],\n",
+       "     [-134.189264780738, 18.0028759737636],\n",
+       "     [-134.05639012943, 17.8024358999627],\n",
+       "     [-134.193070544898, 17.6077869292982]]]},\n",
+       "  'properties': {'forecast_id': 7,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 7,\n",
+       "   'sea_ice_concentration_mean': 0.598457,\n",
+       "   'sea_ice_concentration_stddev': 0.488646},\n",
+       "  'id': 7},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-134.05639012943, 17.8024358999627],\n",
+       "     [-134.189264780738, 18.0028759737636],\n",
+       "     [-134.051929429459, 18.1970170725974],\n",
+       "     [-133.919075813339, 17.9963616784872],\n",
+       "     [-134.05639012943, 17.8024358999627]]]},\n",
+       "  'properties': {'forecast_id': 8,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 8,\n",
+       "   'sea_ice_concentration_mean': 0.592506,\n",
+       "   'sea_ice_concentration_stddev': 0.483969},\n",
+       "  'id': 8},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-133.919075813339, 17.9963616784872],\n",
+       "     [-134.051929429459, 18.1970170725974],\n",
+       "     [-133.913954173994, 18.3904367635838],\n",
+       "     [-133.781124764869, 18.18956413488],\n",
+       "     [-133.919075813339, 17.9963616784872]]]},\n",
+       "  'properties': {'forecast_id': 9,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 9,\n",
+       "   'sea_ice_concentration_mean': 0.597777,\n",
+       "   'sea_ice_concentration_stddev': 0.488098},\n",
+       "  'id': 9},\n",
+       " {'type': 'Feature',\n",
+       "  'geometry': {'type': 'Polygon',\n",
+       "   'coordinates': [[[-133.781124764869, 18.18956413488],\n",
+       "     [-133.913954173994, 18.3904367635838],\n",
+       "     [-133.775336142994, 18.5831348576946],\n",
+       "     [-133.642534155469, 18.382043096616],\n",
+       "     [-133.781124764869, 18.18956413488]]]},\n",
+       "  'properties': {'forecast_id': 10,\n",
+       "   'date_forecast_generated': '2022-02-17',\n",
+       "   'date_forecast_for': '2022-02-18',\n",
+       "   'cell_id': 10,\n",
+       "   'sea_ice_concentration_mean': 0.5989,\n",
+       "   'sea_ice_concentration_stddev': 0.489004},\n",
+       "  'id': 10}]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Take a look at the available features\n",
+    "response.json()[\"features\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9d0d3a2",
+   "metadata": {},
+   "source": [
+    "## Retrieving all available data\n",
+    "Let's get the latest available forecasts (probably made today or yesterday) for a particular date in the future: we'll choose two weeks from today."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0e783d1a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-04\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set the target date\n",
+    "target_date = (datetime.datetime.today() + datetime.timedelta(days=14)).date()\n",
+    "print(target_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b17bab",
+   "metadata": {},
+   "source": [
+    "The API has a hard-coded limit on how long a query can take, so to retrieve large amounts of data we define a convenience function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3205cb8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As Azure has a hard-coded 230s timeout we must retrieve the results in batches\n",
+    "def get_api_batches(base_url, batch_size):\n",
+    "    start_index, n_data_points = 0, batch_size\n",
+    "    responses = []\n",
+    "    # Retrieve 'batch_size' points, starting from where we ended the last batch\n",
+    "    # Terminate when there are fewer than 'batch_size' points returned - indicating the end of the dataset\n",
+    "    while n_data_points == batch_size:\n",
+    "        response = requests.get(f\"{base_url}&startindex={start_index}&limit={batch_size}\")\n",
+    "        n_data_points = len(response.json()[\"features\"])\n",
+    "        responses.append(response)\n",
+    "        start_index += batch_size\n",
+    "        print(f\"Loaded batch of {n_data_points} forecasts...\")\n",
+    "    print(f\"Finished: loaded {sum([len(r.json()['features']) for r in responses])} forecasts in total\")\n",
+    "    return responses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "721d267a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded batch of 50000 forecasts...\n",
+      "Loaded batch of 47527 forecasts...\n",
+      "Finished: loaded 97527 forecasts in total\n"
+     ]
+    }
+   ],
+   "source": [
+    "# In order to retrieve all the results we keep making requests until the API stops returning new data\n",
+    "responses_north = get_api_batches(\n",
+    "    f\"{api_base_url}/collections/north_forecasts_latest/items?date_forecast_for={target_date}\",\n",
+    "    50000,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "903ad8c5",
+   "metadata": {},
+   "source": [
+    "We have now retrieved data for all grid cells that have a non-zero forecast for sea-ice coverage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1cb72e1",
+   "metadata": {},
+   "source": [
+    "## Loading into GeoPandas\n",
+    "Rather than looking at the JSON directly, it is probably better to deal with a library that understands GeoJSON.\n",
+    "In the rest of this example, we will use `geopandas`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "50373d96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>forecast_id</th>\n",
+       "      <th>date_forecast_generated</th>\n",
+       "      <th>date_forecast_for</th>\n",
+       "      <th>cell_id</th>\n",
+       "      <th>sea_ice_concentration_mean</th>\n",
+       "      <th>sea_ice_concentration_stddev</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POLYGON ((-135.00000 16.42471, -135.13294 16.6...</td>\n",
+       "      <td>1365379</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.266712</td>\n",
+       "      <td>0.388724</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POLYGON ((-134.86706 16.62370, -135.00000 16.8...</td>\n",
+       "      <td>1365380</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.799883</td>\n",
+       "      <td>0.399941</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POLYGON ((-134.73351 16.82196, -134.86644 17.0...</td>\n",
+       "      <td>1365381</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.799996</td>\n",
+       "      <td>0.399984</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POLYGON ((-134.59934 17.01950, -134.73226 17.2...</td>\n",
+       "      <td>1365382</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0.601116</td>\n",
+       "      <td>0.488534</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POLYGON ((-134.46454 17.21632, -134.59746 17.4...</td>\n",
+       "      <td>1365383</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.600000</td>\n",
+       "      <td>0.489898</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            geometry  forecast_id  \\\n",
+       "0  POLYGON ((-135.00000 16.42471, -135.13294 16.6...      1365379   \n",
+       "1  POLYGON ((-134.86706 16.62370, -135.00000 16.8...      1365380   \n",
+       "2  POLYGON ((-134.73351 16.82196, -134.86644 17.0...      1365381   \n",
+       "3  POLYGON ((-134.59934 17.01950, -134.73226 17.2...      1365382   \n",
+       "4  POLYGON ((-134.46454 17.21632, -134.59746 17.4...      1365383   \n",
+       "\n",
+       "  date_forecast_generated date_forecast_for  cell_id  \\\n",
+       "0              2022-02-17        2022-03-04        1   \n",
+       "1              2022-02-17        2022-03-04        2   \n",
+       "2              2022-02-17        2022-03-04        3   \n",
+       "3              2022-02-17        2022-03-04        4   \n",
+       "4              2022-02-17        2022-03-04        5   \n",
+       "\n",
+       "   sea_ice_concentration_mean  sea_ice_concentration_stddev  \n",
+       "0                    0.266712                      0.388724  \n",
+       "1                    0.799883                      0.399941  \n",
+       "2                    0.799996                      0.399984  \n",
+       "3                    0.601116                      0.488534  \n",
+       "4                    0.600000                      0.489898  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Look at the first few rows of data\n",
+    "geodata_north = pd.concat([gpd.GeoDataFrame.from_features(r.json(), crs=\"EPSG:4326\") for r in responses_north])\n",
+    "geodata_north.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "100bffba",
+   "metadata": {},
+   "source": [
+    "Let's convert from `EPSG:4326` (World Geodetic System projection) to `EPSG:6931` (NSIDC EASE-Grid for the North Pole)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3e32f652",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>forecast_id</th>\n",
+       "      <th>date_forecast_generated</th>\n",
+       "      <th>date_forecast_for</th>\n",
+       "      <th>cell_id</th>\n",
+       "      <th>sea_ice_concentration_mean</th>\n",
+       "      <th>sea_ice_concentration_stddev</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POLYGON ((-5400000.001 5400000.001, -5375000.0...</td>\n",
+       "      <td>1365379</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.266712</td>\n",
+       "      <td>0.388724</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POLYGON ((-5400000.001 5375000.001, -5375000.0...</td>\n",
+       "      <td>1365380</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.799883</td>\n",
+       "      <td>0.399941</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POLYGON ((-5400000.001 5350000.001, -5375000.0...</td>\n",
+       "      <td>1365381</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.799996</td>\n",
+       "      <td>0.399984</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POLYGON ((-5400000.001 5325000.001, -5375000.0...</td>\n",
+       "      <td>1365382</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0.601116</td>\n",
+       "      <td>0.488534</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POLYGON ((-5400000.001 5300000.001, -5375000.0...</td>\n",
+       "      <td>1365383</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.600000</td>\n",
+       "      <td>0.489898</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            geometry  forecast_id  \\\n",
+       "0  POLYGON ((-5400000.001 5400000.001, -5375000.0...      1365379   \n",
+       "1  POLYGON ((-5400000.001 5375000.001, -5375000.0...      1365380   \n",
+       "2  POLYGON ((-5400000.001 5350000.001, -5375000.0...      1365381   \n",
+       "3  POLYGON ((-5400000.001 5325000.001, -5375000.0...      1365382   \n",
+       "4  POLYGON ((-5400000.001 5300000.001, -5375000.0...      1365383   \n",
+       "\n",
+       "  date_forecast_generated date_forecast_for  cell_id  \\\n",
+       "0              2022-02-17        2022-03-04        1   \n",
+       "1              2022-02-17        2022-03-04        2   \n",
+       "2              2022-02-17        2022-03-04        3   \n",
+       "3              2022-02-17        2022-03-04        4   \n",
+       "4              2022-02-17        2022-03-04        5   \n",
+       "\n",
+       "   sea_ice_concentration_mean  sea_ice_concentration_stddev  \n",
+       "0                    0.266712                      0.388724  \n",
+       "1                    0.799883                      0.399941  \n",
+       "2                    0.799996                      0.399984  \n",
+       "3                    0.601116                      0.488534  \n",
+       "4                    0.600000                      0.489898  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Convert to EPSG:6931\n",
+    "geodata_north.to_crs(6931, inplace=True)\n",
+    "geodata_north.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "696103e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded batch of 50000 forecasts...\n",
+      "Loaded batch of 50000 forecasts...\n",
+      "Loaded batch of 50000 forecasts...\n",
+      "Loaded batch of 3353 forecasts...\n",
+      "Finished: loaded 153353 forecasts in total\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>forecast_id</th>\n",
+       "      <th>date_forecast_generated</th>\n",
+       "      <th>date_forecast_for</th>\n",
+       "      <th>cell_id</th>\n",
+       "      <th>sea_ice_concentration_mean</th>\n",
+       "      <th>sea_ice_concentration_stddev</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POLYGON ((-5400000.001 1575000.000, -5375000.0...</td>\n",
+       "      <td>2146943</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>154</td>\n",
+       "      <td>0.771382</td>\n",
+       "      <td>0.327183</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POLYGON ((-5400000.001 1550000.000, -5375000.0...</td>\n",
+       "      <td>2146944</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>155</td>\n",
+       "      <td>0.749444</td>\n",
+       "      <td>0.334100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POLYGON ((-5400000.001 1525000.000, -5375000.0...</td>\n",
+       "      <td>2146945</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>156</td>\n",
+       "      <td>0.741106</td>\n",
+       "      <td>0.338866</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POLYGON ((-5400000.001 1500000.000, -5375000.0...</td>\n",
+       "      <td>2146946</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>157</td>\n",
+       "      <td>0.746626</td>\n",
+       "      <td>0.335574</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POLYGON ((-5400000.001 1475000.000, -5375000.0...</td>\n",
+       "      <td>2146947</td>\n",
+       "      <td>2022-02-17</td>\n",
+       "      <td>2022-03-04</td>\n",
+       "      <td>158</td>\n",
+       "      <td>0.751134</td>\n",
+       "      <td>0.334430</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            geometry  forecast_id  \\\n",
+       "0  POLYGON ((-5400000.001 1575000.000, -5375000.0...      2146943   \n",
+       "1  POLYGON ((-5400000.001 1550000.000, -5375000.0...      2146944   \n",
+       "2  POLYGON ((-5400000.001 1525000.000, -5375000.0...      2146945   \n",
+       "3  POLYGON ((-5400000.001 1500000.000, -5375000.0...      2146946   \n",
+       "4  POLYGON ((-5400000.001 1475000.000, -5375000.0...      2146947   \n",
+       "\n",
+       "  date_forecast_generated date_forecast_for  cell_id  \\\n",
+       "0              2022-02-17        2022-03-04      154   \n",
+       "1              2022-02-17        2022-03-04      155   \n",
+       "2              2022-02-17        2022-03-04      156   \n",
+       "3              2022-02-17        2022-03-04      157   \n",
+       "4              2022-02-17        2022-03-04      158   \n",
+       "\n",
+       "   sea_ice_concentration_mean  sea_ice_concentration_stddev  \n",
+       "0                    0.771382                      0.327183  \n",
+       "1                    0.749444                      0.334100  \n",
+       "2                    0.741106                      0.338866  \n",
+       "3                    0.746626                      0.335574  \n",
+       "4                    0.751134                      0.334430  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now let's do the same thing for the southern hemisphere\n",
+    "responses_south = get_api_batches(\n",
+    "    f\"{api_base_url}/collections/south_forecasts_latest/items?date_forecast_for={target_date}\",\n",
+    "    50000,\n",
+    ")\n",
+    "geodata_south = pd.concat(\n",
+    "    [gpd.GeoDataFrame.from_features(r.json(), crs=\"EPSG:4326\").to_crs(6932) for r in responses_south]\n",
+    ")\n",
+    "geodata_south.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4ee008f",
+   "metadata": {},
+   "source": [
+    "## Plotting retrieved data\n",
+    "We can now plot this data on a world map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2803fd22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load geometries for all world landmasses\n",
+    "world = gpd.read_file(gpd.datasets.get_path(\"naturalearth_lowres\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b07a02ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Construct a circle with radius 5400km centered on the North pole\n",
+    "boundary_north = gpd.GeoDataFrame(\n",
+    "    {\"origin\": [Point(0, 0)], \"geometry\": [Point(0, 0).buffer(5400 * 1000)]},\n",
+    "    crs=\"EPSG:6931\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1c42a517",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select only those landmasses that intersect with the boundary (NB. we have to manually exclude Antarctica)\n",
+    "world_north = gpd.overlay(\n",
+    "    world.loc[world.continent != \"Antarctica\"].to_crs(\"EPSG:6931\"),\n",
+    "    boundary_north,\n",
+    "    how=\"intersection\",\n",
+    ")\n",
+    "geodata_north = gpd.overlay(geodata_north, boundary_north, how=\"intersection\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8bf64c74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ... and the same for the South Pole\n",
+    "boundary_south = gpd.GeoDataFrame(\n",
+    "    {\"origin\": [Point(0, 0)], \"geometry\": [Point(0, 0).buffer(5400 * 1000)]},\n",
+    "    crs=\"EPSG:6932\",\n",
+    ")\n",
+    "world_south = gpd.overlay(world.to_crs(\"EPSG:6932\"), boundary_south, how=\"intersection\")\n",
+    "geodata_south = gpd.overlay(geodata_south, boundary_south, how=\"intersection\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d51264c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABAoAAAI4CAYAAADjxguwAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOzdd3xb1fk/8M+52vKO7cRJnL3YpDSlAcosgTDDCBRMCCFt6Qh00X7b8muhpS3dpZRCC6VOyGKFkIRNKIQVwk4CZG87sR1vWdbWPb8/FCmSLdmSLelqfN6vl1+xpat7Hzu27j3Pfc5zhJQSREREREREREQAoGgdABERERERERFlDiYKiIiIiIiIiCiEiQIiIiIiIiIiCmGigIiIiIiIiIhCmCggIiIiIiIiohAmCoiIiIiIiIgohIkCIiIiIiIioiwlhKgVQhwWQnwW43khhPiHEGKXEGKzEOKU/vbJRAERERERERFR9loEYGYfz18EYNKRj1sA/Ku/HTJRQERERERERJSlpJRvAmjrY5NZABbLgA0ASoUQw/vaJxMFRERERERERLlrJIC6sK/rjzwWkz6l4RARERERERHlmAvPLZCtbf60HOujze7PAbjCHnpYSvlwKo/JRAERERERERFRAlrb/Hj/5dFpOZZu+E6XlHLaIHZxEMCosK+rjzwWExMFRERERERERAmQAFSoWocRrzUAbhVCPA7gywA6pZQNfb2AiQIiIiIiIiKiLCWEeAzAOQAqhBD1AO4CYAAAKeW/AbwA4GIAuwA4ANzc3z6ZKCAiIiIiIiJKiIRfZkZFgZTy+n6elwAWJLJPrnpARERERERERCFMFBARERERERFRCKceEBERERERESUg0MxQah1GyrCigIiIiIiIiIhCWFFARERERERElKAsWh4xYawoICIiIiIiIqIQVhQQERERERERJUBCwi/Zo4CIiIiIiIiI8gArCoiIiIiIiIgSxFUPiIiIiIiIiCgvsKKAiIiIiIiIKAESgJ8VBURERERERESUD1hRQERERERERJQg9iggIiIiIiIiorzAigIiIiIiIiKiBEgAfsmKAiIiIiIiIiLKA6woICIiIiIiIkqQqnUAKcSKAiIiIiIiIiIKYaKAiIiIiIiIiEI49YCIiIiIiIgoARISfi6PSERERERERET5gBUFRERERERERImQgD93CwpYUUBERERERERER7GigIiIiIiIiCgBElwekYiIiIiIiIjyBCsKiIiIiIiIiBIi4IfQOoiUYUUBEREREREREYWwooCIiIiIiIgoARKAylUPiIiIiIiIiCgfsKKAiIiIiIiIKEHsUUBEREREREREeYEVBUREREREREQJkGBFARERERERERHlCVYUEBERERERESVIlawoICIiIiIiIqI8wEQBEREREREREYVw6gERERERERFRAtjMkIiIiIiIiIjyBisKiIiIiIiIiBIgIeDP4fvuufudEREREREREVHCWFFARERERERElCAuj0hEREREREREeYEVBUREREREREQJ4KoHRERERERERJQ3WFFARERERERElBABv8zd++65+50RERERERERUcJYUUBERERERESUAAlAzeH77rn7nRERERERERFRwlhRQERERERERJQgrnpARERERERERHmBFQVERERERERECZCSqx4QERERERERUZ5gooCIiIiIiIiIQjRLFAghaoUQh4UQn8W5/bVCiC1CiM+FEMtTHR8REVG+4bmZiIgofipEWj60oGVFwSIAM+PZUAgxCcDPAZwhpTwewA9SFxYREVHeWgSem4mIiPKeZokCKeWbANrCHxNCTBBCvCSE+EgI8ZYQ4pgjT30TwANSyvYjrz2c5nCJiIhyHs/NRERE8ZEA/FDS8qGFTOtR8DCA26SUXwTwYwAPHnl8MoDJQoh3hBAbhBBx3e0gIiKiQeO5mYiIKM9kzPKIQohCAKcDeEqI0DwM05F/9QAmATgHQDWAN4UQJ0opO9IcJhERUd7guZmIiCiW3F4eMWMSBQhUN3RIKadGea4ewHtSSi+AvUKIHQhcnHyQxviIiIjyDc/NREREeShjUiBSShsCFxrXAIAIOPnI06sQuGMBIUQFAuWOezQIk4iIKG/w3ExERBSdBKBCScuHFpJyVCFEqRBihRBimxBiqxDitDhe8xiAdwFMEULUCyG+DuAGAF8XQmwC8DmAWUc2fxlAqxBiC4DXAfxEStmajNiJiIhyEc/NRERENFBCSjn4nQjxKIC3pJSPCCGMAKyco0hERKQdnpuJiIhSZ+KJVvmnVVPScqyrJ278SEo5LS0HO2LQPQqEECUAzgIwDwCklB4AnsHul4iIiAaG52YiIiIajGQ0MxwHoBnAwiPzFj8C8H0pZXcS9k1ERESJ47mZiIgohSQE/JnT8i/pkpEo0AM4BYE1lt8TQtwH4GcAfhm+kRDiFgC3AEBBQcEXjznmmCQcmoiICPjoo49apJSVWseRQXhuJiIiTfHcnN2SkSioB1AvpXzvyNcrELgYiSClfBjAwwAwbdo0+eGHHybh0ERERIAQYr/WMWQYnpuJiEhT+XBuVmXuVhQM+juTUjYCqBNCBDs5fBXAlsHul4iIiAaG52YiIiIajGRUFADAbQCWHemqvAfAzUnaLxEREQ0Mz81EREQpIgH2KOiPlHIjgLQu10BERESx8dxMREREA5W7KRAiIiIiIiIiSliyph4QERERERER5QUJAb8UWoeRMqwoICIiIiIiIqIQVhQQERERERERJUjN4fvuufudEREREREREVHCWFFARERERET98nq9kFLCaDRqHQqR5qQE/DJ377szUUBERERERP3S6/Woq6uDz+dDaWkpSkpKoNPptA6LiFKAiQIiIiIiIuqXEAJDhw5FXV0dDh06hIaGBhQWFqK0tBRFRUVQlNy9u0rUm4CK3F31gIkCIiIiIiKKi9lsxsSJE7Fv3z50d3ejq6sLXV1dUBQFJSUlKCkpQUFBAYTI3QEUUT5gooCIiIiIiOImhMCIESNQX18Pp9MJnU4Hk8kEl8uFjo4O6HQ6lJaWorS0FGazWetwiVJCgj0KiIiIiIiIQkwmEyZMmABVVSGECFUQSCnhdrvh9XrhdrshpYTZbGaFAVGWYaKAiIiIiIgGpGdfAiEEzGYzKwkoL/iRuxUFufudEREREREREVHCWFFARERERERElAAJAVXm7pQaVhQQERERERERUQgrCmhAPC4PXl32FtobO7Dol49rHQ5Rwmb/6DJ86aKp+MJ5J7LBEhHlBLfbi1df/Qy2Thce+c+6o09ICQAQ8ujXwn/kMfXIvz4VUNXA435/4F+fH1DVwGv8/sB+/Crg9QY+VyXCSakGHpNhj6tq6GsZ3FfwtVKF9Pshj3wOoUAoAkJvABQBodMBOh2gUyAMBkBRAIMeEAIwGiH1OkAnII16SEWBNOqg6o+8nwsBCEBGe39P9DaZGt9mQsr+N4pHknbTe78y8HPp+ViaiPBDhR9XCEgR+Peaa0/F9OkTcPLUMTw3U1bI5R4FTBRQQlR/F+BaDX3X3Zh5SeCx67+ubUxEA7MJAOBouRuWoqGA8Wwoik7jmIiIEhc4Nz8DQ9dvcdEXA4997TxtYyIamIUAAGf7b2C2DgWMZ/HcTKQRJgooLqq/A3C/Cvg7gO4/aR0OUdJY/HcCHQBMs6GavgqYz4SiGLUOi4ioX6q/HXC/AqjdgP0PWodDlDRmzy8BDwDTVVDNFwKmr0BRDFqHRZRXmCigPjU5WlGqboDBvx5wPqV1OESp414R+PDNQatyISymqbAaTFpHRUTUi+qtB7wfAd4PAOeTWodDlDrulYEP61yoxrMB4xehKFatoyICEJglpEpOPaA84/C68UHbHmzprMPCPe8ceXS2pjERpYcLwGp8b4oHk4uGY9qQ8b3WiCYi0oLqtwOeDYB3E+B4SOtwiNLHsTjwUfQzqPpjAcOXeW4mSjEmCiiClBJvNG3FJ+178dj+d/p/AVGO+sf2FwEAV1R/CdeOOQ0Ti6o0joiI8pWUEtK1FvB8DDhrtQ6HSDtdR6bYmK+DLLgRwjBJ23gozwn4kbtNN5kooJB99sNYvOdNPHfoY61DIcoYq+o/wKr6D/DNCefh+rFfQaHBrHVIRJRHpG8XpP0RwLVS61CIMofrcUjX45AF34MomAehFGodEVHOYaKA4PC68cT+9fjXrrVah0KUsf6z+zXoFR1GWctx3rATWPJIRCml+u2BUuvuv2sdClHm6v4HJBRI/XjAdAHPzZRW7FFAOUtKiQ9ad+N/jZ/hmfr3tQ6HKOP9a+daXDN6OrbZDuHC4SdjUvFwrUMiohwjpYR0vw24X2ajQqJ4dP8dsFwPeDZDtV4JhdMRiJKCiYI8tdd+GBtb96LVa2eSgCgBTx3YAABo99hxesUUfLliEqcjEFFSqN6dgPtDCHRAMklAFD/nY4F/ZTtU0zkQpjM4HYHSgj0KKGc4fG48dWADur1OLNr7ptbhEGWtZw9+jGcPfoy5487ClOIROL/qRAiRuycLIkodqdohHUsB2Q10PwSpdUBE2cr1NOB6GtJ6C6ThBAjzhTw3Ew0QEwV5QkqJdU1b8NONy7QOhSinLD6ScPu8sx6XjDgFk4q5OgIRxSewmsErQOdtWodClFscDwMApHc+pOUqKIbJGgdEuUhKwR4FlN322g9jdd0HWM7lDolSZvm+t7F839u4cdyZmDf+HBQZLFqHREQZTPXuBBxPc7lDolRy1AKOWqjWb0MU3sLpCEQJYKIgh3V7XVhd9yHeaN6CT9r3aR0OUV5YsvctHHK0Y+aIqThr6LEseSSiCKpqBxyPA67XAN+HWodDlB8c/4b074e0XAFhOofnZkoafw5XFOTud5bn9nc14+Fd/8Pfd7zAJAFRmv2v6TM0u21Yvu9ttLvsWodDRBlC9ewG7PcB9j8xSUCUbu4XIfz1kI5FUH1tWkdDlPFYUZBjfKofaxs2w6DT4zFONSDSzJ+2rAl8IoExBRX4yrBjtQ2IiDSjql7A9TyEYoF0PKp1OER5S3b9JvCJqkI1TIRiPlvbgCirSQAqVz2gbHDY1YmFu9fh6br3tA6FiI64b8eLAIBvTTwfc8efBYPCt12ifCL9DUDXw4BrGVczIMoU3X8EAKgFP4Qo/AaEMGgcENHgCCFmArgPgA7AI1LKP/R4fjSARwGUHtnmZ1LKF/raJ6ce5Ij1h7fj0nV/ZJKAKEM9tOtVnPHKnajvbtU6FCJKE9X1GmTz2YCLKw4RZaTueyGbjofqq9c6EspKAn6ppOWjzyiE0AF4AMBFAI4DcL0Q4rgem/0CwJNSyi8AuA7Ag/19d0wUZDmP34uFu17HDz5mKSNRNnjywLt4o2mL1mEQUQqpqhuq7QGg49tah0JE8eiuhep6TesoiAbqVAC7pJR7pJQeAI8DmNVjGwmg+MjnJQAO9bdT1sBmsWZXJ5468B4W7VmndShEFKfH969Hu6cbLS4bLhl5Csx6o9YhEVESqd4mwLkUcDykdShEFC/nUkC2QvU1AtaroSgmrSOiLCABqDIjehSMBFAX9nU9gC/32OZXAF4RQtwGoADA+f3tlImCLPVW41bs6m5ikoAoC73csAkvN2xCs8uGC0dMxbiioVqHRERJoDr+B6HugmSSgCj7uF4E8CKgNkM1XwbFOF7riIjCVQghwpfLeVhK+XACr78ewCIp5V+FEKcBWCKEOEFKqcZ6ARMFWcbt92LJnjfhk37UMklAlNVq966DR/pxbPFIzBhxktbhENEASemG7Po3IBTI7vu1DoeIBsPxAAA3VP/JUCwXah0NUVCLlHJajOcOAhgV9nX1kcfCfR3ATACQUr4rhDADqABwONYBmSjIIge6WzD7rb9pHQYRJdHSfW8BAGxeB2aOmIoCg1njiIgoEap3L9DKwQRRTnE8AgBQ/XcB1iuhKFaNA6JM5c+Mln8fAJgkhBiHQILgOgA1PbY5AOCrABYJIY4FYAbQ3NdOmSjIEq81foZPO+r635CIstIft67BB2278Y2JX8XEoiqtwyGiOKjOFwHvp1qHQUSpYv814HkPsug2CMMkraMhikpK6RNC3ArgZQSWPqyVUn4uhLgbwIdSyjUAbgfwHyHEDxForzBPStnnqr1MFGQ4h8+NJ/atxx77YbzcuEnrcIgohV5r+hxtnm5cP+Z0nDPseAiREQ1yiKgHVXUA9kWAug9wrdI4GiJKKc9LkLZ2SOtNEOav8txMIRIiU5oZQkr5AoAXejx2Z9jnWwCckcg+mSjIYHtsTXim/n08ceBdrUMhojTZ2L4PG9v34bbJMzGrehqKjSx3JMokqmcb4HwCcC7TOhQiShfve0Dne5D+n0GaZ0PRF/f/GqIsx0RBhlp/eDs2tOxkkoAoT92/4yW0eLpw7ajpGFlQrnU4RARAda0DPG8zSUCUr+x/ANRGqNa5UPTVWkdDGUDNjB4FKcFEQQZ6pWETPmuvw+MH1msdChFp6LF978DmceD6MWdgcskIrcMhymuqcw3Q+WOtwyAirTkWAWon1IKvQzFM1joaopRhoiCDSCnxWuOn+MWmJ7QOhYgyxPOHPsHzhz7Bv0/9Jk4ZMk7rcIjyjpQS0vkiYGOSgIiOcD0DuJ6BHPIYhPGLWkdDGpES8GdIj4JUyN1aiSyjqir+s2Mtfr7pca1DIaIM9O33/4O3Dm/TOgyivKKqfkjb/YDtB1qHQkQZSLZdD9W5TuswiFKCiYIM4PF7sXDPG3hk7zqtQyGiDLB84nw8PvkbvR6//ePFeKuJyQKidFBVN9D9IOD8p9ahEFEm67wl0L+E8pIqRVo+tMCpBxrr9rnx1P538dCutVqHQkQaq62uAQC4XK6Y23T6HHjp0Ce4cPhULtFElCJStQPdS4Hu+7UOhYiygFBboDqehbBcynMz5QxWFGiozWXHY3vfxoM7X9E6FCLKQMHEAQAsHHUDAODuT1dAlcDiPW/AL1WtQiPKWar/MGT3QqD7b1qHQkRZQtrugBBeSPt/IHluzhsSAqpU0vKhBVYUaOSQow1L976FFXXvaR0KEWlo5QnfRUdHR8zng8kCKSVqq2tQUVGByzf+AwDQ6OrED4+9BEaFb+VEyaD66oDuWi5/SEQJk50/C/yrNgHFP4UQRo0jIhocVhRoYIetAX/4fBWTBER57vHJ3+gzSRBNS0sLnjr2WwCAp+vewz2fPQO7L/ZUBSKKj/RuATrvYpKAiAbHuQSy887AFCbKeX6ItHxogYmCNPu4dS/+vu0FbGjdpXUoRKSh1SffBofDMaDXdnV1YfnE+QCAFw59gr99/hxaXLZkhkeUV1TXu5Cdvwe8b2sdChHlAtdKSNvvofqatY6EaMCYKEijbZ0H8VLDRnzYtlvrUIhIQ6tOuhWtra2D2kd4w8MqlwkPbXwBnd28e0GUKNX9GeB+DvCxyo+IkkcYvwg4l0H1De58T5lLgqseUBJ82LobbtWHVfUfaB0KEaXZsgk3w+12h75ua2tLyn5rq2swv345Ti8YBwA4dKAOxrFjYbFYkrJ/olynutYDHfO0DoOIcpC0BXoWCN1oqOqxUIzHahwRUWKYKEgxVVXx3KGP8dvPVmodChGl2bszfoO9e/f2udzhYIWvjOD3+7F3716MHj0ahYWFKTsmUbZTVRVwPQPYfq51KESU44IJA7X0USjm0zSOhih+nHqQQlJKPLDzZSYJiPJUU1NTXEmC+fXLYTQaQ2svz69fjvn1ywd0TFVV8UHdNqxr/HxAryfKdVJKoOsvTBIQUXp13ATV+arWUVBScXlEGqBFu9dhyd63tA6DiDTS2dkZ8zkhBEpKSnDVZw8CAObsWdRrm2Cy4LFJX4fT6YzrmKEEw37gwZPnYdrwyYkFTZTjZNeDgPMRrcMgonzU+V2oymNQTF/UOhKifrGiIEXeatqCf+1aq3UYlMHen3mP1iFQivn9/qiPV1RU4Oa6ZaEkQbhovxfX7/xv1AoDIQTm1y8PVSIAwMJRN4Q+L+5C3AkGonygOl4BHPdpHQYR5THh3w7Ve0DrMChJVIi0fGiBFQUpsL3zEG7/ZKnWYVCGO/WlO7QOIS8EB94D/XkvGj0HpaWlKC8vx5mv/3rQ8RQWFuLyjf+I+XysOBeNngNVVaMmDG6uWxbqVSClDD1eXl6O/fv3Y/z48TAajYOMnCi7qe5PAdutWodBRHlO2n4FUXwPVGGBoq/UOhyimJgoSLJPWvfio/a9WodBGeT9mfcwKaChRH/2Pf+/VFVFW1sb2tra8OQxt0Cn08Fut4eqBQoKCvC17f+Juq/59csjmg0KIXDttocH8F0A8w70nXy0Wq1wOBwAjjY47OjowNx9i3GrMgOXjJmGclPRgI5NlO1U1wbA97HWYRARAQCk7Q7AfA1k8e0QyhCtw6EBkhLwa7R0YTokbeqBEEInhPhECPFcsvaZbXbYGrC6/gM8vIuNSugoJgmyS/D/67lTfhAxyAcAu92Ozs7OiCkF3d3dUffz4pdu7/XY0KFDkxhppOt2PNKr2sDpdGLJuJsw1FSCf257KeZUCMpdPDcDquczwPkMYP+71qEQER3legrS9ltINfp1BJHWkllR8H0AWwEUJ3GfWaPe0Yp/bHsR77ft0joUIkqCSz/+e+jzhaNuiCjp7+mJKd/sVVVw0Qd/BYDIwXt9UkOMqmcVg9frxQiPASfpqvD7T5/B/510BYwKi8nySF6fm6VvL2D7G+B7W+tQiIh6cz0HCTNQ8isIwSmC2UirFQnSISnfmRCiGsAlAPKyjXCrqwt/38okAWWe92few6aJSXBz3bI+n49WVVBbXYMnj7kF7874TarCiqlnZYEiBCbIUozyWPHPjc8F1pCnnJfv52bVdxjS9kcmCYgos7lWQHb9C1Ly3EyZJVkpkL8D+D8Aefcbbve6sGzv23izeYvWoRD1cupLd3DqQ4IeP2Ehhhfaej0erYlguNrqmtBHkN1ux6FDh5IeYzx6roagCIEvWkfjAuNENDY29lkhQTnj78jTc7Pq7wK6/wt4XtM6FCKifgn9KEjHE1qHQQmSEFBlej60MOhEgRDiUgCHpZQf9bPdLUKID4UQHzY3Nw/2sBnBo/rwTP37WLr/La1DIaIkqVAMcPmTU5ovhMDVn/8rKfsaiHHjxkGv7/29tLW1YW9jGuZBkGby+dwspRtwPg44F2odChFRXKTtZxBCD9XxrNahEIUk42r4DACXCyEuBmAGUCyEWCqlnBO+kZTyYQAPA8C0adOy/laWKlWsqnsf929/SetQKI24gkFqDHYJw2Q6f/OcmM8pihK1bD9YbRCsJgj+29+UhVQ7583fRn180eg5cLR24pDegBGVVWmOitIkL8/NUvohu58E7H/WOhQiooRI2/8DAKgQUKyXahwNxUsFVz2ISUr5cylltZRyLIDrALzW80Ik16iqiicPbMBftuZtE+m8lQkD2Vzx1rl34dXTfwYgM6ZInFTR/xQBg8HQ67HwKQnBz+fXL+93qoKW5h1Yivn1y9HY1oK1dRu1DodSIF/PzbJ7KWBPf18QIqKksf0IqpPTpkh7bH09AE/sW497d7ygdRhEWemlU3+Mjo4O7Ny5EyUlJVqHE7K5ZUS/2+j1erjdbgCB6oJ5B5b22iaTEwQ9fXtvINYRhUNwfNlojaMhGiT7EsDxO62jICIavM5vQ1VWQjGdoHUk1AcJaNY/IB2Sup6DlHKdlDKna2VePPgJkwR5hqsGJMdb596FhaNuwKFDh+BwOAAEBtvZJFhRYDAYoiYJstXN7/0bu22NWodBKZIP52a1eyWTBESUW9qvgurlimqkney6StfYO4e34eO2vVqHQWmmdUl8rjh48GCvTvvRSvkzmV6vR2lpKW7c+6jWoSTd0/Xv4aCjTeswiBKmuv4HePvs2UhElJ0cS6H6tFk9ieKjSiUtH1pgoiBOWzvr8cOPF2P1wQ+1DoUo47193q9CnwcrMoJVBOEu/fjv6QlogJweA0ou3omSi3cCAC7f+A9c9dmDGkeVGisOvIfH969Ht9eldShEcVPdnwId3wFcT2kdChFR8jmXA45aqGrvayiiVGOiIA52rwtvHt6qdRiUBm+de5fWIeSE3bt3o7a6BrXVNdi+fTsWjrpB65ASYnuvErXVNShaWgwAWNrwz4jkR656Yv96LNv7ttZhEMVF9dsANxt+EVGOcywG7P/VOgrKQ0wU9ENKiecPfoz/7n5d61AoDXbv3q11CBlhsH0Z/H5/6HOv19trygEAmM3mQR0jlSxNgX//++uLce/mu+ByufCV136laUzp8sie1/DiwU+0DoOoT1JKwLkKcDygdShERKnnuB+q83mto6CepICapg8tcNWDfrzSsBGfdhzQOgxKg9rqmpxqUJfpLBaL1iHEJI7kNYIJj2HDhgE5WFT04pduh9/vh16vx8z3/xJ6/NmDH+G4kmqMKazUMDqi2KRzDeDdrHUYRETp43gKquEEKPoxWkdCeYKJgj7s6WrCB6178EojL0bywbBhw4B6raPIDPE2cPzfGT+Hz+fDhe/9GQCwdPw8eDyeuF5bUFAw4PhSqW1TJYrDvp5fvzwnfy+WT5yPhoaGqM992LYHq+o+wLcmnQ+z3pjmyIj6pnq3A573AfcarUMhIkof73rA8Thk0Q8hBM/NmUACUMHlEfOOy+/BO83bseYgOynnutrqGgDAJR/dq3Ek2efgwYM4ePBgqB9BvEkCALhgw59SGNnAFYctbDJ8+HDtAkmhR8fcCJcrsmlhbXUNHp/8jdDXy/a/zd4slHGk2g243mTzQiLKT47/Qjpf1ToKyhOsKIhh4a51WLh3ndZhUAq8P/MenPrSHaG73/Prl2sdUtYyGo3w+XwJv85kMqUgmsS0dhSivNQO90uVkF9tx7BZgUHxv3d+HU6nM2crCRaNnhPRQyKcw+EINHEsKsI1Wx9Cs9uGN5u24Kxhx6U5SqLoZNe/AOfDWodBRKQdtR6q63Uo5nO1joQAzfoHpAMTBVGsbdjMJEEOO/WlO7Bsws1wu93Q6/knMBjRljyMR2FhYZIjSdyaE2dBURR878OVwD+24omWh9DY2Ain05kRiYxUWHnCd9HR0dHvdl1dXVg46gbcvH0Zrhr1JUwoGoaR1vLUB0jUB9WxhkkCIiL7XwDz16AaJkPRjdQ6GsphHCX1UN/dgoPdbVqHQSkUniSYu2+x1uFklTfPuRNnrbsbQODOtKqqA9rPrE33JzOshPhUBXpFhZQSfr8fDy2+HjrdHBw6dCi0zciRI4EULYDxwrQfQVUDx1dVFWazOdTjIdXiSRIESSmxaPQczDuwFGZhxHemzIBJxzmRpA2vax90apPWYRARZQbXE4AwQy38CRSemzUjwYqCvOHyebDu8FY8uOsVrUOhFKmtroHX6x3UdAOj3gePL//+dN6feQ92796N2uoaCCEGnCQQQrs31I5uC9TdhRhyUnPosZ5VEcOGDcM5b/42of0+ffx30NXVFdfPpLGxsddjC0fdgMLCQpSUlGRU74bg97P8wDsoMxXgpgnnaBsQ5SVVVbGvzosJRelJqBERZQXno4BSARR9S+tIKEexmWGYp+veg6LhIIZSK9i0sKSkJO7XFJlc2DB1BYx6HzZMXYENU1fgzRNWpSjCzOZyueB0OgEcWcN8gKxWa7JCSljhq4EkgeO13sv+CSFQXV2dcFPL2uoadHZ2DjhxAgR+nl1dXaivr49oKKglIUREQu2gox3rD2/XMCLKVw0NDXC73XAWfaJ1KEREmcW/H6r7ba2jyGuqFGn50EL+3RaNYV3j57hv+4tah0EpsPrk29Da2hr6+spPH4i5rVHvw/TK/fjTsMAF6UF/F5Z1jYEiIgfGG6auiLmPZV1DcP/u8wYZdeY5a93doWTLYHxt+3+SEM3A6GcFKgmenHdhxMBeCIGb65YBdb1fs/78u9Hc3AyHwwG32z2ohEA8HA4H1kz9Hi7f+I+k7vfRMTfGbGIYLla1zaqDH2DVwQ+w5qyfoMpaltTYiGLp7OxEe3s7AMBsNgNdGgdERJRJXCsA1wqoFW9C0VdpHQ3lGFYUADjoaMP/bVymdRiUIuHz4fubcuDx6fFmwwRM3zgb0zfOxjWfzcMNRW1Yd/zquI93Q1FbqPoglywZd9Og95EJK0y89pU7eg32b67r/fffYbfgjbN/id27d6O1tRVOpzPlSYIgKSXen3lPUveZrMadl7/5Z/jU/hMORIPldrtx8OBBAIDBYIBoPlbjiIiIMlTLWZCS5+Z0k0hPNYFWFQV5nyjwqj48sOMlrcOgFFo24WYAgE6ni/r8yKJOvHXy4xED++BAf/3JTw/q2MFpC7lgIMsgZqKeDf1iJS/eP/827NmzB16vNw1RRfL5fDj1pTuSuk+32x1z2sf8+uW9phr0Zfm+d5IZGlEvqqqirq4ulJwzm80aR0RElNlk96Nah0A5Ju8TBU/texevNn6mdRiUQm63GwBw0/4lUZ9/esJarHOZMX3jbADAmhMXJfX4b56wCv8+bmlS96mFCRMmDGrZwEyoJuh8vxI2my30dUFBQdTt2mxW1NfXD6oXw2B0dnZi0eg58K3u3Ushmhem/Siu7RwOR69kgaIETgNjxoyJOz6nz4NN7fvj3p4oUU1NTXC5XKGvS0tLtQuGiCgb+DugejZqHUXeUSHS8qGFvE4U7LQ14O872JcglwXn1PfVaf8pewl+uf0KAIEKgKG6wqTHMdVozvrpCGetuxuVlfENXHvSsoFhuHdvvSli+kC0fgkt2yqw6rgr0hhVdKqqYvGCGVg24ebQ7/FTx/bubFxbXYPGxkYsHHVDqHqmLw6HAxaLBVarFUajEfMOBJJY570d/1SH/+55DVs669Hp7o77NUTxstlsob4yiqJg7NixKHJ+SeOoiIgynPPfEN6NUH2dWkdCOSJvmxm2u+x4t2WH1mFQmkSbgx70110z0hhJIBlx1mdXZOUSi8GmYvFSFAVDhgxJemO+gQpfmjBa8qj9k0qsuSz1vw9GoxF6vR6qqkbcNQ0nhIDFYoHD4YDZbMbisXNht9tjNpSUUsLtdoeWr6yqqsJFH/w16rbB1SuMxoGvvXzvtufR4enGtyfN0HTJS8otPp8v1JcAAEaMGAGr/RQNIyIiyh6y6x7A3wYUx1dpSIMkoVn/gHTIvpFKkvyv6TP8c8fLWodBKRRvl/dwbumFSRhSFNFRwSUWg9MdMk2wkV74PPnlE+ejuzv+O8ihqQYHkhragC0dPw8ejyf0dUFBQai0v/zhDVjWcD8OVx9O2fENBgP0ej3cbjc8Hg88Hg/0ej2EEL2mOJhMJqiqCofDASCwNKWiKHFPhZBSoqGhAYtGz4FOp4vZZ8Hj8WD1ybdFNPxMxMI963BcaTXOHnrcgF5P1FNjY2PofdtgMKDYdarGERERZRnHv6EavwjFfLbWkVCWy8upB1s76vFx+x6tw6AUWnvaT/tMEri8kTkyKQMDyVMe/F6qQ4uwYeoKfHv8myk/zivT/y+h7U996Y5QksC3uhKLRs+JeecbQKgRXvhHJll10q0RSQIAuHbbwwCAN//8Tfx3759x+HBqkgRCCFitVni93l4rJ/h8PlgslojtgwP7noN7KWWg87sQMBqNMBj6T2ipqtpvM8bOzk48+4XvJ/AdRXrmwPtw+T39b0jUD4fDEWo2WlxcjEkll2kbEBFRtupeDindWkdBWS7vKgr8qh+P730HrzaxgWGuCJZiGwwG3Lg30PE1vHQ1KHj3WD+rGfrnywCnhLXJC/cQPf5zx4WhgeT0jbMxb9y7+HZJ732kwrziw5h90lKcv3lOyo4R7efRHykBPFmBxbfP6HNZwExLCkTTc8pEWVkZXqj6EdontGPfvn1JP57ZbA5VALjd7lBlQDTBBoNutxt+vx8GgyFqUkZKGRr0ezyeUAIiuO/wzxPh8/nQ0tKS8OuC1rfswJP738Xc8bxzQQMnpcShQ4eg0+kwYsQI9iQgIhoM7+uQ9uUQRf33LqKBk+DUg5zySuNmvNi0SeswKEmWjLspNHgKJgken/yNXgOmxyd/A7OxGq/85kZc8MslWHzrDOj1evj9fiiKEqo+sLQcuYM+6zQsinK8RaPnhAbNx1VclbTvo1AJNDtMxVSEhaNugJQStdU1UQf1tdU10Ov1mLtvMQBElOM/uO3m0KoRPYUnZjLZc6f8IKJaYH79cqAeMef6D4bFYoHX6+2z+iKa4O+ryWSK+7VSSjgcDphMJiiKEuplkOixg/sajH/ueBnnDjseowoqBrUfyl9tbW1wuVwYOXIkkwRERMnQ/XuolvOh6EdpHQllqbxKFHR6HNjakZ67xJQewSRB+LJ90e6qXrfjETz3y1vR2NiIxQsCzep8Ph8AxJyi8MyJC9De3o7jKq7CtF9/BwDwzasexYoTfoBhIvPvni4eOxc+ny9iEFhbXQOdToeb9i+JGCjP3bcYvtWVWLxgBm5f+HuoR6oroiUJFEVBRUUFLv347xGPG/U+3Db2dVxd2I6Ltl2GTpel12u10NbWFvo8mCgJJk+Szel0wmq1hn63EhUrKRPvaxLpyWEwGFBeXn70gfqEDx1hXeMWzBl/JhsbUsJ8Ph8OHz4Mq9WKEveXtQ6HiCh3uF4BCr+udRQ5LZcrCoQW64RPmzZNfvjhh2k/7sM7X8Uju19L+3EpfR6b9PVQR/dw0RrG9UVRlIhyeyEEioqKcMXvn4Z+VnNaljkcaHXB08d/B52dyV8aJ1o1Ql8/hzM/vRJevy7u/Rt0/oS2D/erKWvwVbMDBqGP+LmtPe2nmPHuHyO2TdXPJ5zBYICiKAMa+A+GTqeLK1mQiuki35tyEcYXDsXplVOSvu94CCE+klJO0+TgOUKrc7Or8xkYnT8FADiLPkFLSwu6urpgNBoxsfjS0HbthndR5j0t7fHlGqUqcsUntXGyRpEQUcoV/hjQHw/FfIYmh8/1c3PxlGHyS/++IS3Heu28e9P+s8ybioLP2+uYJMhR78+8J9R4L1bZdaIJsZ5z8qWUsNlsAwtwgAYyFWHx2LkpGQQXFRX1esxqiN3A7ocNX0xo0D+l7DAeHRPZ1NEtvTh383X9ZmqPJisCb2dGvQ8enx63T1yLjo5v9do+HXe8wytdYjUnTAW/3x+aihBMjkVLnKXCP7a/iJoxX8EXysbBoh/4souUXxwOB9raLRhhBvY5XoKjZW/oOY/Hg+3tq8OSXw0QIzag1DNdm2BzBBMDRHnE/hfAcnNgFQTFrHU0OUdC5HRFQV4kClSpYk93k9ZhUIoEkwRvnnMndu3aldJj6Wc1B+bwT03pYRISvuzfQEveo+nrrrMiJF47fk3M599tGhfXMR44bjm+aIw+qDQJA9af/DS2ebsxf8vcmG/EZ2y+Cu+ctDL0tcenhyIk/rprBq4c/R30/M9KZ2l8sKIguFJBz5UXUnnMIIPBAIPBEDElZ/nE+ajZVZv0Yy/f/zamlIzARSOmJn3flHuCDQxdrmp02FcC6D1trGeFTFtbG0oL0xQgEVEucC4EDMcD1su1joSyTF4kCl5v/BztnvjXf6fsdNa6u/HUsd/CNVsfSkmjOiAwx9/4QyP+07kK3yxpSMkxgq7Zc37o82CDQQCQAlD1wOPfmQm/35+SwWdfSQKfquDM4bujPqdCxWU7Lgl9/cK0H6GxsREWiwXX/GUN9LOaQ88VmVwxkwThjjEUYP3JT/d6fFnXEPx739l468RnIh7vOR3ip0MCyaNgdYYWc+illPD5fNDr9UlN5sQjWM2g1+thNBohpUyol0Gi1jV+hhNKRmFUQXn/G1NeCzYwTITL5QKYKCAiSozrJaiGL0AxsLFhsklWFGSvdnc3ttoOYvHe2GvVPzHlm5BS4rodjwBAaLAZ9Nikr8PtdkeUoxcXF2P2ln+nLnAakPD/t1TxeDx4rOlL+GZJ7DvqyVBnKwVwpDv/AmDuA2sBAEsXXJDSwV6sJMGTx9wCu92OSz98Hn/4wgYAhl7bXLj1cnS5j5a2Xfzh31BbXQOn0xlqInnpx89jzwX/HXScNxS14YYeSYJ4aNVsT1VV6HS6Xv0v0sXn84WSFIn8DILJnnj7Grx+eAu+UDoWXxt3BhsbUkzBBoYD0aiuQ5VyTnIDIiLKZZ5Xge4qoPROrSOhLJLziYIXDn2MassQAAgtD9ez4V13d3foeQDo6uoKPRcc5PRks9ki7lqHLy9H2nrq2G9F/B+mQrcn/XOwgwPtVDYg1ev1kBLwr6mMeHzxghmw2+0AgNKPjDi76nrMGrUZPy/fAa/04dLts+Je5eC5Uy7BlpZLMGzYMJT709dcZ/3UJ3H6xmthtVrR2tqatuOGS+Wd/ET0tVxmT1arFQDi3h4ATnaXo6urC8XFxYOKk3JXU1PTgP8eOjs7UVWW5ICIiHKdYoTqfhuK6StaR5JTVOTuTZGcThRs7TyI+7a/iJUnfDc0qI818O8p0dJ1n8+HpePnYc6eRQMJlQZo7Wk/RWNjI27c+2josVQnCfR6Pfq6UXre55fD4TVi/dQnoUAZ9PHm1y9P2VSKnoYPHw7/fZXYcN8C7N69u9eF/Pz65TAemVmwuu4krK47KeL5zvcrUdAAvP6H+Th8+HDMrv/z65cfWY5vdlpWkAAQ+r8IroIQPvBN18/XbDZHXb5TK7XVNRg+fDgu+uCvMbc5583fhratra5BRUUFLt/4jz736/f70dDQgMLCQijK4P8GKLc4HA60t7cP+PV+vx/ukk0wdZ6cxKiIiHKcoxZw1EIO+xRCmPrfnvJezl7BqVLFot3rAAAdHR1pOabH48HCUTfg+S/+MC3HI6C+vh5erxerTroVQKBMOtXKygK3slT0Lh//7sEvw+E1wreqEl/88PqUx5JM8+uX48w3/4qPHvwB6urqoiYJYnG/UAnf6kp88IOv48nbL0NdXV2fSwM+PvkbeHfGbyAlsNGT2BzlZAn/ftJRIm80GjMqSRDU0NCAlSd8N+7tW1paUFtdg6Xj5+HZL3w/6jbBlR6am5ujPk/5K9jAcLCYJCAiGhjZvUzrEHKGlIAqRVo+tJCzFQWvHNyEGdZJmDPypP43TiIpJZqamrB0/DwUFRVh1qb703r8fBI+xSC4dGE61q0vLCzEuJK2qNUCvx1zLxpNjVC+p6CiogJQnxjQMW7af1bE11arNeWDzMVj56Lmvhex74R9Uatugnfdg70SAEB3eTPcPj3W3/NNNDU14cCBA3Edy+FwYM+ePfCvqcS3xRwAgEHn79WYMF3Ky8vR0tKS0mPo9fq0rHowEB0dHaitrkFhYSGu3fZwXK/xeDwxEwE6nQ5+vx8tLS0oLS2FycQ7FxTQ3t6ecAPDnvj7REQ0CPY/QDVfCEU/UutIKMPlZKLAp/pR4tKhyGeAVtNGPB4PWltbE774pviFTzFIZyd5nU6HUdboZbNDfKfj4vpAd/3lxvmQRW+hUp6J37YcgynmBlxT2BnXMRz+yB4IxcXFKU8U+Hw+LF4wI9SzI5Zgr4Rw+/btS/h4brcbS2+7EHPufxn6Wc14aPiNOH2TEnWFg1TxS4GPLvpdaInNdE1ByFR2uz3hKVTBn1lxcTFMJhMu++Q+zNmzCLXVNZBSorGxEWPGjElRxJRNfD4fmpoGv1SxxRJfPxQiIorB+TRQ9D2to8gJXPUgyxw+fBhFrsyZVWG32/HCtB/h4g//pnUoOS9V3eTNZjMURUFBQQHOWnc3FDEeGPZJr+2CS/ABCFunPvDYczgBwZngP5v0Iq4oiD4g/9TjDK14EFRWVobW1lZ4vd7BfisZRVXViMTDIyNvwH7nLRhlmZGU/g59eX/mPQCAU1+6A49P/kZGTgtIh8LCQjgcDqiqCkVRQkmCd2f8Bqet/WVou/n1y7HyhO/GnMoVrOrpmWzp6uqCzWZjY0MaVAPDcGazGUjvKqNERDlF6EZC9XwOxXi81qFQBsu5RIHL5UJbizYdzfvS1NSEdWf9ItQYjAYn1p3fVDUyPDroD1ClwI37z8aSMW9EPH7/sY/htq3RexO8fd6v0NjYCCEELv99Jf5weaBse1xJGx4b9xqAyEQDAPhWB1YfmHnxdeh8YVJe3PHu7u7Gbs/zGD16NN5vOhn37L8YL055YcD780ofzt78tV7zu4JVBEDqEkzhUrlaxUDp9Xpcu+1h+FQFeiXyZxCeJAi66rMHQ58n8rvY2NiIoqIiLpeYx5xO56AaGIYb4js9KfshIspX0vZzwHoLVP0UKErODQfTSLv+AemQObfdkyRTm2dJKbF37168evrPtA4lJ5WUlOCV6f+X9AGfwWCI2cRvd0cFbGrkXP4vmQx4+sSFUbf/ymu/gs1mQ2dnJx773kWhx/d2DsH0jbNx4bZLIrb3Hlmi8LEfXIx7N98VGpjFu0RdNvN6vdizZw++XfsdND8+BtfvPS/xfUgfTt90Nc7cdF2/b+I1u2pT3p0/E6tBCgoKAAA6kdpEicfjQWdnfNNuKDclqwcIpx0QESWJ42HAs17rKCiD5VQKKdMvRqWUOHDgAKchJIEQIuIO7dWf/wvLJtyc1GPodLqIZRd7UqXABZtvBABMG3oA/xzxPgCgRBigU1T41ciB58tf/gkOHjwIIDBXt7a6JlDqfWSOfqfr6AWw89VKGGSgH0DPAWY+VBUAgb+Xp66dAYvFgmv+sgbTZw0BAFgNHtw54VnsdFfh1dbjsN/W/4LqbZ9WoHiPQPlDUU6IQsHBp4/FvANLU/qz9fl8sFgscS3Pmi7BChy/VKBPMFnQ82+wP83NzSgpKWFVQR5yu91JOzePK7io/42IiCg+jichTWfy3ExR5VSiINVdy5OlsbERq066FVds/qfWoQAIdLu3Wq2YveXfWocSt54DlNrqmqSveGC1WuFbXQn9rN5VKr7VlSh/aD3q7jodxV9uxsfNo+Advh4GoUehYsYQswPNjsLQ9l1OEwwGQ6/9BCsgyud1oOnKSSh/eAOEIuD7RiWe/r8r+m0smA+cTicWL5iBuQ+shX5WMxxeI3627eo+X2N3GVG2rAjFnzSiacYIvHv3HKiqCnnX9VBVNfC5lBH/qqoKt9ud0ikCyZifnUyqqqK2ugbFxcUJ/f2/O+M32LlzZ0JNRN1uN7q6utirIA8l69ys1+fUJQsRkfY8r0B63oEwfUXrSLIWmxlmAa/Xm7T5j+nQ1taGJ4+5JSNWQ5g0aRLq6uoi7qbmQ3l7f7q6uvDGn76Bs//vEehnNcO3uhLCD9hHAU8vmAEcacIXrAo4U16Hp09ciB/svzIiSeBbXQkLAHFB9DeSxQtm4IcPrUf5Q834x+d343vH34nyh9ZD/PTKdHybWSOYLAAAnwWwj5GomNIS6OOgAk/+5DJ4vd6jg/G7jr42GZ3Wk8Hj8cBsNg96ebhks9lsWDjqBpSWluLKTx/od/tdu3YNaKWR5uZm9irIM16vN2YDzESVl5cDmZVrIyLKfp5PACYKKIqcSRS0trZmZLOwvtjtdiwaPQfzDizVNI7T1v4S68+/G7t374bX64XFYsGb59yJs9bdrWlcACLm5ddW14T+TZf9+/cDAFyvVOKxWy+I+jumqiqkCCQEPphUBV+PKQeFB33471+vwN69e2Me597NgVFt+B1ni8UCu92ejG8jZ0RbmhELAv9k2uA720gp0d7eHvo764vRaBxQzwWn0wmHwxHqjUC5r6WlJSnnZiEEysrKgOwoHCQiyh7d90M1nQnFOFXrSLKOBHK6maHQYnA9bdo0+eGHHyZtf36/H9u3b09L5/JU0el0uGn/koRft+qkW6GqauiOjaIoGD58OC58788DiuPRMTcOKI5kefOcO7Fv374B3a1MBUVRUFlZicOHD8d1sXvVtmdQWWKH168LPZZoYkNRFBgMBqiqmpEN8GjgrFZr1i3DaLFYMG7cOEx/5Rehx1780u1oaGgY0P4KCwsxduzYJEV3lBDiIynltKTvOI8k+9zs8/mwY8eOpJyby8vLMUycnYSoiIgoGqVqR9L3mevn5oLJw+Xx/0huj7RYPrjo92n/WeZERUFra2tWJwmAQLKjtroGOp0ORUVFKCkpwVff+X3M7ZdPnB9YCrKtLfSY2WxGdXX1oCoBoiUJ3p95T8RScsHHAPR6fDCeO+UH2Lt3b0bN41ZVNaGy9dJCZ0SS4OnjvxOziVesZnDBufLRehpQ9jIajVmXJAACVQA955gP5m/UbrfD6XSye30eaGtrS8q52WAwYOjQoUBmLmpERJQTtnc2YkpJldZhZBcJZFlBe0KyfnlEVVXR2tqqdRhJ4/f70dHRgf3796O2ugZLx88LPbd47FzUVtegtrqmV5l1RUUFanbVoq6uDovHzsWK477d77Hen3lPaMDf3/M9twsmCPrbR3/WTP0elo6fh9rqGhw+fDijkgSJqqwMLGdYYnaiwBhorHj15/8KzKuNYvjw4UwG5JFsTmY2NzfjrXOPNn0Y7Htupi5jS8nj9/uTdm4eOXIkRPOxSdkXERFF90nbAa1DoAyT9YmC9vb2rB5c9mfOnkUAAuXrscrxhw4dGhpwut1u+Hw+2Gw21FbXYPnE+aHtnv3C97Fo9Bw8dey3Il4fa6AfrYogPHEQ/nzwuXiSBkvG3RT6nlpaWuDxePp9TaabX78cl31yHwDgxWOexf+Oezb03KxN92PEiBG9XuP1emE0GtMWI2nHarVmzHSagZBSYteuXaGvB/uea7PZkr5KCWWWZJ2b9Xo9rPZTkhARERH15bpxp2odQlZSIdLyoYWsnnogpcyaJRH7E60MfX79cqw++baIuzKlpaUoLi6GogRyPMEKhGu2PhR1Lnyw8mDhqBtCd/GCa6cfOHAAXq8XHo8nagOzl079Merr63HVZw+GHouWDDj1pTsiHnvj7F/i7Dd+E4onOBgOJgS8Xm/oOUVRYDKZACCj1pePpaCgAKWlpbjwvT+HvoeRI0cC9YHn/3zMCihH8m8bpq7A9I2zAQAz3/8L3jznTng8HkgpIaXEBRv+1CtpQ7lHCJEVv9v9kVImtZFoS0tL4G+Hco6qqkk7N/t8PmxpWQkAGDJkCKqUc5KyXyIiIupbVjczbG9vx8GDB5MQkfaCzQzfPOdOuN1u6PV6nPvW7wAEGhYCwBWb/wkgMBBvb2/HFZv/mfQVAGI1WysvL0d5eTm+8tqv8PZ5v8JXXvtV6LnwfgWvfeUOHDhwAKqqhlYoCN+n0WiETqeDEAJ+vz/irmKmN3qLZ8nIDVNXRH08mDDo6e3zfoUDBw5E7dhvMBjYzDAHZPrvtVaEEJg8eXLSpt/kesOkdEjWubmtrQ2HDh1KQkS9FRUVYZQpyuonREQ0KGxmmDjrpOHymPu+npZjfXLJ79L+s8zaREGwFDaXylcNBgPKy8tx8Yd/i7lNsIlhquj1+rhLpIUQuLluGYBAsqC9vT3iTntQIgMlk8mUkf+nwaSHEALV1dWY8e4fo24XK1EQ5JRunLvphojH3p3xG9TX14cqPYKYKMh+QggoipLT06MGo7y8HMOHD0/KvnL9YiQdknVu3rlzZ8qnlHEVBCKi5GKiIHG5nijI2qkHXV1dGTmgHAyv14vGxkYsGj0HhYWFmL3l3wCAlSd8F1d99mDUJobJ5vP5Igb2QgiYzebQ80IIeL1eeL3eiFLkPXv2wOFwDLrCwev1JpSsSJfg9yWlxIx3/4il4+fhgg0rMXSoLbTNxdWf97sfizCFkgnBKoPT1v6y13EoN1gsFlYT9KGtrQ2VlZXQ67P2VEQ92Gy2tPSd8fl8AHvBEhGRpgRUqU3/gHTIymaGUsqc7pqtqmqoGeFjk76Ojo6OtA4gHQ4HzGYzzGYzpJRwOp2hD4fDAa/XC51OB4vFAovFAkVR+hwMJXJXXFVVKIoCITL3j662ugYejwfPnXIpfKsr4VsdWO3ghfrjE9pPtOqDkSNHZvT3TvEzGAxMEvRDSplTq9bku3Sem7liDBERUWplZaKgu7s7J5qD9cdsNmv2fbpcrj6rF/x+fyh5oKoqDAZDqMEicLQSwWq1Jlw+7/F4IqoYMtniBYG5ssFkQaIUETn158L3/ozx48fzIjgH8P8wPm1tbZyakSPsdnvKq96CSkpK0nIcIiKivkiZng8tZGW9Zy5XEwQFm/1li57JACnloC4YnU5n1jSBW7xgBoQQKC0txfSN/fcpCLf+5KcBRDY7PPuN32D9+XejoaEBnZ2dyQ6XKKP4/X60t7ejoqJC61BokNJ1bjYajTB1npyWYxEREeWrrEsUOBwOdHd3ax1GynFu89EpEOm6QzUYUkq0t7cfmSISf6IgqGffgtNfvTP0XKLTTubXL8eTx9wCu92ecByUPKqqpuU4VqsVALL6/aKlpQVDhgyJqEqi7OJwONLyO3hcxVUpPwZRLMFmb2rjZI0jIaJMIdmjIHPkw3xWzm0+yu12530J9/z65XH3LSgvLweApHWSp4FLR7NVvV4Ph8OR9Y1dfT4fq2eyXEtLS8qPEavp5UHv/1J+bCKACQIiyi9ZlSjw+/2w2Wz9b5jldDqd1iFkjODynZl+p9FoNGLYsGE4puKKQe3nxZMWR3385rplcSUMggmmM1//NYqKigYVCw2OlDLlvTaMRiOAwHujxWJJ6bFSraOjQ+sQaID8fn+v5V1TYXLp5VEf7+zsRHfBRyk/PlFQKpaRIyLKNJk9+urBZrOFBo65ymKxZEWpfTp5vV6YTCatw+jTnD2LcMlH9+L0jdcOaj9lirVXg8NwN9ctQ3l5OUpLS1FSUhIqOw8Kb37JOd/aS3WCK/z90OVyZfUyg93d3Qk3PqXM0NnZqfm5uaD7i5oePxwrHHIXEwREFC7QaFCk5UMLWXVVmQ93nHw+n9YhZKRMbm5YWloK1Ac+T6SRYSxzxryHxfumx3x+1qb7I75+85w70d7ejo6ODlitVrw/8x4AgUHkMcccg9NfvROvfeUOHD58OCN/frnM4XDAYDCkbAAcPjiTUkKv12f1e0hnZycTXFkoXefmLS0roSgKjhlyRcRjmda3oLOzEyP5a5xToiUIktGvgD0PiCiTZU2iwOv15nwTw0wdCGcKh8MBi8WScUtjGgyGpCQIgi4t3Iql4stQj2QPDTo/3jrxGQBAu+rApZ/NgV89eqf6rHV3R+5ga+99nvf2PRFfLxx1g+Z3APNFvP0lkrFvl8uV1e8jHR0dTBRkGY/Hk9bfN1VVsaVlZcRjmZQs2NKyMjQliLJXIpUDPbeVUsJms+HQoUOQUkJRFFRUVES8t0kp4ff7Q2W9TBgQZS81h5sZZk2iINcbXQkhsr4hWTo4nU4YjUZ4PB6tQwnx+XxAktpKuKUXf2g6H6oU8Ph1cDiNKC08mhgpU6x456TIi2QVKs7cPDsiedCfm+uWhT5fffJtedEkVCsejyelg3edThexlGowoeb1erOuusDlcsHlcqW8twMlT6acm/c5XsJY60zNjt9l+QBFzi8BAAoKCjSLgwYmfKA+0OkFXq8XLS0tsNlsEVVkqqpGVEs5nU4cPHgQLpcLRUVFGDNmDHw+H/x+PwxDt0FRFCYMiCgjDDpRIIQYBWAxgGEAJICHpZT3DXa/PeX6tAMuhxg/VVUDJ9I0LT/Xn+G6c5O2L5Mw4C9T/oWG4gZ4PB5IKTFy5EjAHbtiQYHSK3kQzit9OHvz12JmPGdtuh9Lxt3E+eEp5HA4eiULDAZDqIeBTqfrNY1AURS43W6YTKaY7w1OpxNCiF7LiAarbgwGAwwGAzweT9YkDTo6OlBVVaV1GFkvHedmKWXGnJsdDgdg7X+7VKmrqwOwEgaDIdBIlqfzrBGeGFCqdsDn80Gn08VVDaaqKux2O2w2G2w2W8zrEqfTCY/HA0VRUFdXF7rZ0dXVhZaWFjQ1NYXOARaLBeOYayLKGrlcoJuMigIfgNullB8LIYoAfCSEWCul3JKEfQM4epcpV+l0uowrp89kPp+v18BIK/PrlwP1s5M39WDoNtRt3x66Q2w2m1Hi/vKgdmkQejx/4hJctHluzG2YJEi9nsmCYCIgntcZDAbodLqov/N9TSHxer3wer3Q6/W9Kg8yVWdnJ4YNG5bSKRt5Ii3n5kyqhNvSshJFRUUYZZqhyfGtVmugqoFJgqwlpcTOnTthNBoxYcIEAIFVPTo7O9HV1QVFUULLDzc3N6OtrS3uaXx79uyJmrBtbGyM+NrpdGKLcyUKCgowxnLhIL8jIqKBG3SiQErZAKDhyOddQoitAEYCSNrFSKbcsUiVvu4YUnSZMBd7fv1ynDV8N/407JPk7fTwMZg0aQtaWlrg8/kwQn9eUnZbplhDyYx3XCpu33Z0dYZVJ92Ktra2pByH+uZwOKAoCkwmU0LJmeCAP9Zgv7/Bms/ng8FggJQyYypxYvF6vXA4HCzfHqR0nJs7Ozszrm9MV1cXtnWvimh4mA7HVVyFnZ3PpvWYNHhK1Q7Y7XZIKVFUVASPxwO/3w+n04lDhw5BCIGOjo6I912j0QibzZZwkizRqq7u7m5sdTyDY8uvTOh1RJReWq1IkA5J7VEghBgL4AsA3kvWPqWUGTMHMhX0ej2TBAOUCc0Nk5okADB942wAd4Y9ksRqhSPOMCsw6Pzw+gONFTKp30M+UFV1wL+ziqJETRRIKftNnHm9XhiNRni93oxvZNnR0cFEQRKl6twcHEBlWt8YVVWxtTX9A6xMX8aXIilVO+BwOLBv3z4AwIgRI2AwGELPx0qgNzc3pyM8AIG/sy7LBygpKWHfAiJKu6QlCoQQhQCeBvADKaUtyvO3ALgFAEaPHh33fh0OR06XRRuNxqyZO5yJnE4nTCZT2stf59cvT/oAHkjO8orxeOvEZ44kJYDCwkLY7fa0HJcGJ9jTIBqXywUhRJ9JAI/HA4PBACFERg3serLZbBg+fHif3y/FJ1Xn5u7u7tC5K9P6xmhltPkCrUOgBHV1dYU+P3TokIaRxOZ0OlFcXAwxbHtoSlZ408XwBAJXTyBKLwmR0xUFSbkKE0IYELgQWSaljNpVTUr5sJRympRyWmVlZdz7zuVpB6wmSI5g46F0MBqNKUsSpFvwe7j4w79h6NChGkdD8TAYDLBarVE/jEZjXJUCXq83tBJDpvL7/UxeJUG6zs0+nw96vR5WqzVt78X9KS0t1ToEygKZnDANamlpweeff45t27aFVkvo2YAx+BH+WFCHcQN2dz2f1piJKDckY9UDAeC/ALZKKf82+JCOUlUVNluvGyA5g9UEyREsfU1FozaDwRBR0TJnz6KkHyMTXPrx3wEAz5y4ADabLSua3uUjp9OZtD4DDodDk2qceHV0dKC4uFjrMLJWus/NHo8nNOjSekoYEGgEi9wtRqRBCN11P7JiQbbw+/1ob29He3s7ioqKUFJSAqPRGJryEnwvN5lMEM3Hhl4XqpQoSnvIRHkhsydzDk4yKgrOAHAjgPOEEBuPfFychP3Cbrfn7IBFURRWEyRRMu6QCiEwv345ysvLIYSAxWLBjXsfxciRI1FYWIiioiKsn/pkTlQTBK2f+mTE11d++gBu2r8E48ePR0VFRcR8TdKe3+8PDICSJFPu/kbT1dWVs+//aZKyc3NXV1efyapM6IHR3wDwgOuVNEVCmST8TntnZ2fWvsd0dXWhvr4ee/bswdatW7F161bs2bMn9HWwseaWlthLJxMR9ScZqx68DSAlkzNyedqB2WxmoiDJoq1VHy+9Xo8RI0YAdcCsTfdHPHfhe38Off73Y1VMN+XOvGkFCnSKCr8a+T2d8+ZvQ5/XVtekOyzqQ75UIQUb2Q4ZMkTrULKSludml8sFvV6v6e9qd3c3EKO34O6u5+F227HT/SwmlVyW3sBIM+FJAp/P12tZwlzi9XqZJCBKB8lVDzTh9/sjmszkEiFExpb7Zrt4y6nn1y/v/eC+eJoJZuyfzIC9c9LRiwmndOPcTTdEPG82m+FyudIdFsWg1+uTNq+25900k8kEv98PnU6XEe9RTBRkptLS0tCScrHodDoYDAa4XC5NKgxUVcUB1yu9GgwGkgSB322v14vdXc9jQtElaY+P0ic8QQAc+d04cCBrqwmIiNIlY0c9nZ2dGVG+mAoWi4XVBCnk9Xpj3s0qLCzEtdseDn2tU9SIgXK+swgTNkxdEVoRAQBqdtWyqiBHud1uWCwWeL1eqKoa+tfn88FqtYZ6Imilu7sbXq+XU2AyTElJCXQ6HQ4cOBBzCkJwMC6EgNlsDnVrF0Kk7fxnt9uxy/McSkpK0N7efuScEJkAc7vdnLudR6SUqKury8trsC0tK3FcxVVah0GUe3JzuAogSasepEJnZ6fWIaRMLi/3mAmCS3UFL0yDDAZDRJLg8RMWMkkQp6gVGKSJZA+cnU4nfD4fVFWNGPQ5HA7odDpYLJakHWsgcnkKWjYrLCzEuHHj+u1zIaWEy+WC0+mE0+mEw+Ho9d6cSh6PB83NzXkzZYf65nA4crZaNR49pyOIYdujrppARARkaEWBx+MJzC/MQSzjTg+Px4OCggKYTCZcsfmfocdfOWkJipXgwIe3kWLpWVVAmSOYaBxoP45E+Hw++Hw+TbvYd3Z2IpFl+yh9LBYLxo8fj/379yc0HcZsNmu+KgLlJ15/HdUk30Dbli0wmUxQFAU6nQ4lJe8HVps5fIzW4RFRBsjIREE+Z3tpYAwGAwwGA4QQ0Ov1KCkpwfnr/xCxze0T14YlCag/ipBQjzRo4dSDzONwOGA0GgGkfi1wl8vVa6nQdHG5XPB4PKHvlTKLyWTChAkTUFdXF/dSc06nMy2JLqKe9PqMvOxNq6NVBa0AIpMnXV1dUBQFxcWvwWKxwGQywWo/RYMoibIHmxmmWa5WE+j1emazU6C8vLzXSgUAYND58doJT8EgMvLXPOO9ftLjOHvT9QCgeQdzis7j8UCv10MIkdJeAsF9p/o4sXR3dzNRkMF0Oh3GjBmDw4cPo7m5Oa7XOBwOGAwGKIqieeNMzt3OHyUlJTCZTNi1a5fWoWQsVVXR0dERNu1rJYxGIyZOnMhKA6IMJoSYCeA+ADoAj0gp/xBlm2sB/AqBzgqbpJR93gnMuBGUlDJnEwVGo5GDrRSYtel+SAm894VoKxZk3K941jCJo/Pg5+5bjEWj50BV1VC/AlYZZIZg48FU3531er2aTUHo7u5GWVlZ2o9L8RNCYNiwYbBYLKivr4/Z5DBcsEIl2FBTy/PjlpaV0Ov1GDduHAztJ2oWR6oE55+rjZM1jiS9os27N5lirJtJMXk8HtTX16P6SL7Wbv0QxcXFUBsnQ6nakXe/V0ThMqH3vhBCB+ABADMA1AP4QAixRkq5JWybSQB+DuAMKWW7EGJof/vNuGaGbrc7Z5es0fquSa569gvfRxp7Y+WVN05+LPT5vANLmSTIUOHTEFIpnsFfKnR3d+fsKji5pri4GNXV1Qm9xul0wu/3w2KxwGq1wmKx9NskMRV8Ph9aWlrSflxKjVjN+XL1ZlSq2Ww2bGlZiS0tK3HgwAG0tgamLng8HnSa3oNvyGdsiEiknVMB7JJS7pFSegA8DmBWj22+CeABKWU7AEgpD/e304xLFOTqG7jZbM7ZBIjWjEYjNkyNVk1Ag2USBpxSWRfxWG11DVdByECqqqZ8cOV2uzUZwHm9Xq4Wk0WklAn/nkgpQ6siBBMHWtz5zfaEfqyBmto4mXd9j2hra9M6hJzQ0NCAra3PYMeOHTh48CB27NiBPXv2wFH4sdahZZx6z6vY2/2i1mFQCkgEehSk46MfIwGEX7DXH3ks3GQAk4UQ7wghNhyZqtAnJgooqxkMBvxg54+1DiOnPTjyvYiv59cvj1lRkM5lzyiSz+dLS6Murcp2eW7IHiUlJTjmmGMwadIkHFdxFSorK1FRUYHy8nKUlpbGvR8hBKxWK8xmMwwGA/R6fajiIPhcspfvTFaioOcydOkSLRnQXfAR2g3vahCNdmIlTPx+PxtmJ1HPSi+Hw4F9+/ahwf+6RhFlllbdO9jSshI2mw3jCi7SOhzKfhVCiA/DPm5J8PV6AJMAnAPgegD/EUKU9veCjJGr/Ql0Oh2bGKbA0bvaw4DRmoaS88JXQACAioqKqCW6I0aMwIXv/ZlTEzTidrthNBpTugqC2+2Goihpn4bAPgXZRQiBYx7+J3ZfA1TKM488CEAPjKiIbyAd7bzp8/kghIDBYIDD4YDZbE5q3Mmo/NMqSRBLXV0djhlyhdZhZITDhw9zGlMatLe3Y3iF1lFor9x/Bg6LZ/g7l8skgPStetAipZwW47mDAEaFfV195LFw9QDek1J6AewVQuxAIHHwQawDZlRFQa72J2DjnNQw6n3YMHUFpx2kQbklMoF3+cZ/9Jp+ML9+OS5878+hz61Wa9rio6NSPTXA7/cnfXAWD/YpyD7G9tiXGH2tMnBcxVWhj2jnTyllKBnmcrmgKApMJlPSfi+3tKxEvedVNIu30GkKVFTZzO/joPd/MV/TXfARdnY+G0oSZNL7n5QSW1pWwlH4cd7MIY9WWeFyuULz6in1Mi1hppVjy6/EcRVX8edBqfYBgElCiHFCCCOA6wCs6bHNKgSqCSCEqEBgKsKevnaaURUFuVhNACTnDgX11ulIbslpPrtx/9nY2V6JN05+DOduvg5mvRevHX/0/WViUTOaHYUAgFUn3YorNv8TAPrsVXDdjkdYWaCBdEz/CC5tl86+AV6vFx6Ph4nXLCL7uRURTBb0dQE9oegSoAjY3r465rlUVdXQlIFgP6DB/m7abLbQ5wexEkA9ysvL4S37FJ2dnXA6nZBSQlVVqKoKV8v+0PZWqxUVFRVAahciiVthYSG6urpgtZ8C1a51NOnRMyEipcShQ4c0ioYoMFWWclMm3MOQUvqEELcCeBmB5RFrpZSfCyHuBvChlHLNkecuEEJsAeAH8BMpZZ/Z04yqKMjFRIFer8/65kiZ6q1ptVqHkBNUqNjZXgkA6NIF7p45vEacvulquGXgYvu9w2ND27e1tWHx2Lnwra7sd9/p6MRPkdK1xJyipP/0kYvniJwW56/IcRVXYciQIRBCxLzzNqVsFo6ruKrfRJjL5YLX6036HX2TyYRh4mwcPHgQhw8fhtvthqqqcDqdvaZIeDweHDzYs+JTO8HkWodxg8aRpEe0qomOjo6ULyFLkfqqGspHk0ou0zoEynFSyheklJOllBOklL878tidR5IEkAE/klIeJ6U8UUr5eH/7zJhEQa72J+BAKTUURUGxwoqCZLhw6+Whzw8fPoxHRt4AAFClwNmbrsfpm66O6E+g1+vh8/nw5O2RJz2dosKgi7zjN2fPIsyvX85VEtLI4/Gk5c6F2+1Oe3l1Lp4jcpmaQM1ilXIOji2/EkCgKia4DFu959WI7YJlvP1xOBxJb3ToKt4Ip9MJIPB3Fhx4WiyW0LQHs9kMn8+HKWU9V6XSjpQSlZWVKCsry5upB+HcbjcaGhq0DoOIcpVM04cGMmbqQa72J0jX3b18oSgK5h1Yyr4ESTTE5ESXO3CRG21FA7VHk5YxY8ago6MDw8TZ2DA1+j6nb5wd83glJSWw2+05+feeKfR6fVqmBQQHY8HBU6oF+xRwdY3sIHUDu7I5tvxKNMk30NbWBpvNhvbh76LMe1rC+3E6nTCbzYNuJmw0GuF2u9Hd3Q2LxRJxZzq4rCMQKC1WVTXj7qQ6nU6MHDkyb/5u1MbJoYSI0+nE/v370958lQJLAlYbz9c6DCIahIypKMjFO0V6vT6l3cfzkaqqeOvcu7QOI6c8MT6yQdf8+uVYOn5ezO0tFguGDx/e5z6jJXKClQVXf/4v3LR/yYBipf6ZTKa0DdyBo4OxdPD5fHxPzSaDGJcOE2eHqgd6Jgm2tKwMDcaDTQ9jcblcEELAaDQOuAIm2CDU5XJhrHVm6Lg9BftoZDqlakdOVxYEv7fDhw9j9+7dvGGjESYJKD8ISJmeDy0wUZBCnHaQHD1L1/fv39/H1jQQPQf2c/YsAgAsnzgfC0fdgJe//JPQc9//5HpsqRvZ7z7PGr475nOPTfr6wAKljJTO1Qhy8VyRq1J1XRPsYxDez6CvhEFwlYSBTEfQ6/WhxFvw355Jip7H3d31fELHSLWx1plZkcBIpo6ODhw+fFjrMIiIslpGTD3I1f4EzGInV3iyIFbJOw3c8EIbGuzFoa+Xjp8XKtk9ePAgfKsroZ/VjCnWRozQ9Z9j/NOwTzC9YULU5wZbCkzRKYqiSfPUVC/JGK67uxtDhgxJ2/FoEFJ4AyRasiAeTqcTJpMp6t+JEKJX0stoNIbO5R6PB7tsz2Fi8aUAEDVZkWmUqh1QGyfD6XSiqKgo6nO5RKnaAY/HwxUONJZJy4MSpVwGrHqQKhlRUZCL/Ql0Ol3eZfCTTafToaCgAEvG3aR1KHnhmYmv4HdTngl93fOicvGCGVg46gZcbFoIfxzviotsQ6M+/twpP0jrHeh8kq4pAFoK9imgLJDi/6ZYA/PwxFW0O/6xElsGgwEmkwlWqzX0EUxqBvfh8XiwpWUl9na/GLHfTEwSAAglAtrb26P+3eTiFAS73c6eBBpL59K5RJQ6GZEoyMVqAk47GLyCggJ8bft/UFVVpXUoeeOrlqMJu1mb7u/1vJQSXq8XF22e2+++utTIQWvJxTtheaAMbW1tgw+UMko6B+7sU0A9hd+9NJvNESsOBFdPCOdwOGA2m2G1WmE2m6HT6WCxWODxeOB2u+FwOEIfwQFnz30UFBRgd9fzCVUzaCGYCPB6vdi3bx//digtmCggyg0ZMfUgFxMFNHjBcs8Z7/5R40jyV2FhIex2e8RjiqJAEf0PDJftOzX0uW91JR7e/U10d3dzSk4OSvd0h+7u7tDa8ERjrTOx1fkMpJSBxLIdvaYk9Py65/Sn/hqAhr++pKQEQ3EWhhYBKAJ2dj6bvG8mhbq7u7Fjxw4UFhZCCIFRo0YF3s97VBWET0fIxukJWky/okjpnI5GpCkJzRoNpoPmFQW52p+AJ6rB62s6yvSNs3H6pqvTGE3+2DB1BdZPfRIAcO22hyN6QwDAb9t+i/UnPx33/rxrKvHMz67Kyb/zTKNVSb6qqmnvU0AU7tjyK1FYWIjCwsKoz/e889/fagmxXl9aWgopZcT+JpVcNoCI0yM4yA//fu12O7q6umJWFwRXRQgmELJtekI6V32h6AoKCrLu94aIetO8oiAX+xMYjUaW9w2CEAI31y2L+lz3ukqYOoHyh9aj9VunY9e451BVeD4Kldyfm51OChRsmLoC0zfOBhBoJLlk3E24ce+jOGu4o59XR3rjD1/HgQMHUhEm9aDV+46iKGl9Hw9fx54yWJpvsow2XwC18ejXx1VchW1tq6LOV4+WOIgm2LBwj/0FjC+8GLu7nofb7YaiaH6fZVCCS0bmGlVV2Sw3AxgMBq1DIEqfHG6bpHmiIBcH1Hq9Pie/r3Toefe6pyfmzIBOp4N/wQwAgd+fFtc6nL/jkV5L/NHgbZi6Al7pw5mbrsONex8FEFjNIBHnr/8DaqtrUhEe9eD3+2GxWNJ+R81oNKb14tzr9UJV1awfrOW8DKjGPGbIFahzr8Uo04w+kwPBhED41+HbjC+8GEDgnJOpjQvjET6Fwuv15tQUHqVqBzo6OtjIMAPYbDYMGzYsK6euENFRmicKcrFEP9cqJNJBURTMO7A0rm17/nwdDgdWnXQrACYKUsEg9EzCZBEt3n+0GLB7PJ68WOWBBm+UKZBYPq7iKjSq6+ByuTDWOjM0YNbpdDiuYlZEsqBnMmBHxxpMLr0cx5Zfmd7gU0RKiaamJowePTqu7YNl5Jk86FMbJ6PN8ZLWYRACSaidO3eivLwcXMyWcl8GZMVTRPPbMbmWKBBC5Nz3lGoGgyHuJMHXlqyN+jg76We2/ipFKHm0GEBrcQeP77NZIAPLMauUczDWOhPA0Xn7wVUS+qoUmFx6eVriSyebzZbwNJ5Mn3fOaUmZw+v1orGxMeNXBiGi2DRPFORaiX4uzvlLJr0+sojFYDCEStqBQHf81s6CmK9/cu4FMZ/b1rYK0379HWz0cH5iJohVhcCkQeqlu6pAi5UsmCjIArl7kyWrhSdEDh48GDPRp6oq3G53r+d7NjvUWng8BQW9rx+E4C+iljhFjHKeTNOHBjT/6821iz0uCRObTqfD3H2LI+52VlRUhD5/9gvfxwt3XY+SdVaUXLIbvtWVKLl4JzzPV4a2ubluWcyBpqqqWPGTWfjG736IaR9fm7pvhOLWM1nAJEF6eL3eXkm5VNLiQjzXksxEWnC73di/fz/cbjeklJBSwuVyoa6uDtu2bcPOnTuxZcsW7Nq1C42Njejs7ITdbg/9/WmZNIh23JEjR0YMTM1mMyZNmsRpShpizwii7KVpjwK/359z8/m1Wp4sG9y0fwm8aypR/Kti+P3+QCVBfeC52uoaNDc3H020SBWLF8yA9SezMPvPqwEAj036Oq7f+d8+j+FwOLD4tiONDkt/AWPHSSn7figx4UmC+fXL2eAwxbS4y59OuZZkJkonnU4Xuv7q7u7Gzp07Qwm/aNcxLperV8NSk8mEyspKlJSUQAiREY3rjEYjqqqqcOjQISiKgtGjR8NoNKK6uhp79uzhoJWIki+Hh36aVhTk4oUe73JFZzQaISUgJHDpx3/HjXsfhZSAzWHGwlE3RGzX07A3mgEE1kZ+bNLX4VtdCavV2ufxLBYLkwQZgo0Q0y/dU6C0amZIRIlTqnZg7NixMBgMEdMQghUF8XK73aivr8fOnTvR2toaWDYyA6YjDBkyBMOHD8eECRNC74Vmsxnjxo1j1adG7NYPtQ6BiAZA04qCXLvQ0+v1OX8Xb6Dm7FkE/5pKdEyR+OysX+DAgQMAgJr7XoScfPTCxGKxAADu3XwXgEDJ2t+evjF05yO47NuQIUP6bFpUXl6O6Rtmo9zajecnv5iS74nit2HqCkzfODviMf69pE66l2jV4uLb7/fD5/OldYoFJUjk8G2WLKY2ToalagcmlVwG4GjPgoE2nfN4PGhoaAAAFBQUYMiQD1BYWAjRfGxyAo7ikO81FHV2ori4OOrUp/Ly8l6PWSwWmM1mdHd3pywuis7lcqFQ6yCIUkECkLnbB4UVBUlkMBi0DiFj+VYH+gxUHNMCu90On88Hn8+HxQtmhLZRFAVXbP4n/GHLOrtcrl7TUxYvmIELNvwp5rFKSkpQUlICAGh1xG6MSNqau2+x1iHkHIPBAKvV2qtEONW8Xm9ajxeUa8lmonTqefe/r1Uf4tXd3Y26ujps374d7YZ3B70/ILIPQr3nVWxpWYmOjg7U1dWhrq4u7imsHo+HqyJoxGazaR0CEQ0AKwqSiJ114xMrmz/vwFL4Vlfi8e/N7PfE71tdCfPt5ogBUWgOfD2Az49uO33jbChCova4xTjGwMSBVox6Hzy+wFvOknE3aTa4zGVer1eTn6vX64XBYEj7sd1ud7/TkIiot1i9BI6ruCopy9mpqoqGhga4yl7HcN25cb+uv6kLPd9jbDYbPB4Pxo4d22d1kZQSBw8eZB8pjZjNZohh2yGbpmgdClHS5fLbCisKkohl1NH1TKAEpw/05FtdieXfvyiuuwMrf3olCgvjK2Rr21wJz6qhGF+5O67tKTVGFXaEPg9fEpOSQ+u5t1pMAci1ZHOuyeFqzJx2XMVVSft7bm9vR5t+fdQEQHilQLwrJ1RVVfV6zOVyYe/evX1eg7W3t3PKgQaEEBgxYgRGjhzJJAFRFtIsUSClzLmLvFz7fgbLaDRizJgxuLluGfSzmuE5Mq6P1XV48YIZ/SZbgkkHl8sFkykwR0Gv16O0tDTma4r3Amt/Oxe7du1KWikkJW53R0X/G9GAaZ0o0KKiKteSzUSZYnLp5Tiu4iqUlZXBarUOamplU1NTr3P7QJseFhQUhKYWhnO73di7d2/MioG2trYBHY/6V15ejkmTJqG6ujrUZwoI/F+NHz8eQ4YMYZKAcptM04cGNJt64PP5cmqZGjZmOyq49J3H48FX3/l96HGjffD7vrluGVae8F0AQFFREY455hic/uqdMbd3+3TY9K8for4+sA7j4cOH8YaxAFcU8M6C1sKX56LBy8epT0zOEiXPQe//YLPZoNPpoNfrIYSAXu+D2WxGSUkJzGYzjEYjvF4vnE4nbDZbXHfppZRQFCVpKyKMGDECDoej1zQEt9sNv9/fqxrC7XanvW9LPjGZTKGPkpISOBwOmM3mUPJa6yUziWjgNKsoyLULPHbejhTsF+B9NtDEsLa6BsDRpoYDteqkW3HVZw/iqs8exOmv3tlnksDuMmLTpb/BKd+5N3Q3xO/340f/qxlUDJQcN+1fwr+bJMrHRIHb7eac4wzGRQ+yi06ng5QSPp8PLpcLTqcTXV1daGtrQ0NDA/bu3Ytdu3bB4XCgrKwM48aNw+jRo+NaHrWpqSlpf6s6nQ6jRo2K+lzPG1BSSjQ3NyfluBRoOj1y5EhUV1eH/i0qKgo9L4RAQUFBRIVbJiyZSUQDo1miINdKRrVYRzxT1VbXhBIDS74zI5QcWPP/rhnUfg0GA67Y/M+Yz/ufroRvdSUem/R11FbXYPXxN+CU79wLABH9DF74yiX46pbLBhULxeeaPedj+sbZvZZGDJq7b3FeDnApOYKDGiIavCrlnKhl/eH8fj8aGxuxZ88eeDweFBcXY8SIEf3uu7W1Nanl/1arFRUVvaez9TyfdHR0oKOjI2nHzXeVlZUoKytDaWlp6N/+pqWwooBynhTp+dAAKwoobcLnriVqfv3yPhvgPfuF72PIf9djw30LQs0S3W43nrz9MuhnNUdcPKiqirXHrR5wLNQ/FSqmb5yNOltp1Offn3lPKIHEO8LJka8Jl1xLOhNpadSoUZg8eTKqqqr6PGcHKw6AwJLE8VYVJHPKabREQc9eLVr3bsk1vClGlF9YUZAknGsd2+IFMwAMfiDz5jnRpxl0vVMZKi3suVZvcF6i2WwONT8EgNM3XjuoWKhvPX++frY/T7lce0+NF5POmYt/9tlHbZwMo9GIiooKTJgwAZMmTYpZZRC87hFCxNXsUFVVdHV1JS3WnlPX9Hp9r4FsUVERzGZz0o6Z79ra2hJaBpfVBJQPhEzPhxY0myCcaxd3XBM+NkVRUF5ejrKyMrhL43uNyWRCUVFRqOnlqpNuxVnr7o6+7fRAOWPrt05HZ2dn1G2mv/ILAIEeB+x+nB5+KeB5tQKP3RxIFOl0OlRWVuLiD/+GE/7vXhgBNLcUAdXaxpkLFEWB0WjUtGGXVpUh+ZogIUqFnvPJTSYTRo0aBUVR0N7eHvHcQK7jkv33WlhYCLs90Cm5uLg49Ljf70dzczNsNhunJyWR2+3Gzp07YTQaoSgKpJQwm82hhIyUEjqdLtDvgisdEGU9JgqSQFGUnFrBIVmEELi5bhk2XPDb0ED9qRvnxPWzcrvduGH3wriOY9QF7mosXjAjVAoJhDU8qg+Uup/60h24YvM/8da5dwH1A/iGKC7BfgTqcxV47DszQo8H57Yum3Azqs6owuzhtwKYivkVgcaXwb4WlDhVVeFyuUIXb8HPhRBQFCXi7yJVtKqqyqVzCVGmCq/WMxgMKCgoiOj9E+/ff7LfJ8aMGQObzQYpZUTlQ11dXSiBQMkVPN8EOZ3OXkkkk8mECUU9X0mUgzRcujAdNEkUSClzal6ywWDgXa0ognMDg0mCZRNuTujn1HPgWFZWhis/fSDmsfx+P4QQqKioQEFBAc57+x5gf+D5U1+6I7Ttma//OpFvgwbo8e9dHLXSxu12Y//+/fj7Bz+D3+8PrZARXFaTBi44aDYajREDaKvVCofDkdJja1VVxWououSI1Z1ebZwMk+ml0HuIlBIjR44M3DEuTKyj/WDeh1RVhc/ni5hiIISIOjWCyyFqy+12o2voBygpKeH0A6IsxrXJkoDNXaKbu29x6POXv/wTHDx4cMD7UhQFxcXFaNlWgaJ9AqaZkcsd3bR/CWqra3Bz3TL49ivQK9GrFt756q/hdrsDSQRKumA1wetn/j/s3bu3z22Dd5bCkwNzDzyOxaOvS12AeaLnXXaHw5HyZIHFYkl5MiIaVnNlLi6PmF36GtANHz4cu3fvBgBMLr0csunoa5SqHdDr9XGV+LtcLqiqOqDrJiEE2tra0NHRgZEjR0Ysy9eTwWDglAONNTc3R0wHIcpN2q1IkA6aVRTkknztNt6X4F3ioJaWlpjb6nQ63LR/CQDglen/B6/XC7/fD1VV4ff7QxcUhw4dwpuzr8Xlv3uq1z6Cg83FY+dGPB6erNhwwW+xdetWSCmh8Ao26S7afnHo83Pf+t2AqgOYJEidVA6o01GxEAsbyRKlnsViwYQJE2DqPDni8WAVQllZGRoaGvrdj5QSTU1NqKqqSvjaSQiBYcOGAQD279+PiooKDB06NGrSoWejQ0o/l8uFlpYWVFbtYFUBUZbiOyklndVqjfg62B/ghWk/gqIoOHToUOi5wsJCXLvt4dDXF2z4U9R9rjju2/B6vTAajdDPao66DQD4fL7Q8d1uN5469lu4ZutDAAJTIJZPnA+XywWz3os2/XoM8Z0+4O+TItnckZ2l473DROmRikSB2WyGqqqaJQkAVhQQpYPaOBmmHo+FT1UoLS1FY2NjXDeCWltbUVxcjIKCggHFEpxu1N3dHXEzIVxhYWFSV1iggWlqCpSeFBRvhMFggF6vZ5NDyj05fO+RiYIkyLUKiWSQEgjeLAj2B7j4w78BOHr3v7y8HLM23R/X/mZv+TfWnfWLmOs6h3c+vm7HIzH3U7OrFi9/+Sd4/fg/Y/v27RhSGtfhqR/BKQfhqqqq0NjYyGRBhkj2/4PZbM6IecC51vOGKBv07Geg0+lgNpvjbpw60CUL29vbQ6sbjRw5MuayjCUlJXFVOFDqBZMFQGBKSHk5b9IQZQtNJtfn2kUd72hFUlUV/jWV8Ph1UZ+vrKzE8OHD404SBJ3z5m/x5Zf/X9Tnrt32MMaNG4eqqqp+93Phe3+GEALV1VyXb7Dc0hsx5SDceev/EjH1g7SV7PepTEgSBPE9mEhbbrc77mlAxcXFoWbHibJYLBg5ciTGjBkDk+lojYPH44HNZkNzczPa29shpURpaemAjkGp4/V60djYiCb5htahECWPTNOHBtijIAmCa5hzma6Aml21ACqhPDcEiDJN4LJP7ov5Wt/qSgCAwS5R+7MLUVpaGnOlg57Ofet3ccd46kt3YNkJizBBX9j/xtSLU7px7qYbYj5vdxnx5MTeVQaknWQu45pp73dMFBBpQ1VVHDp0CB0dHXG/ZqBTDoBAoiC8stDpdKKxsRHd3d1Rt6XM1NraCv2wd1DuPyPq8wr7GhBlBE49GCSTyQQhRM4lPwbjmRMXoOLcCpz2gwfRsqMce753O+x2O876yX8AIGaPgWCS4KkfXw6n0wkpZShJ8PKXf4Jzf7kIij/264FAP4Sg4JSH4GPhSyQCYJJggL5dfxo2toyM+fwTU74JRVE4PzSHZdpKL0wUEKVXcBDnLfs0oSQBcLTRoMfjQXNzM1wuF8rLyxOqAJBSoqurC3V1dTGvv+KdBkHaaGpqgs3yIkaMGBHRJDPWMp1EGSuHh4BMFAyC0WiE2+3WOoyMc+WnD6C2ugbLv38RpkyZAqfTiX379kE/qzmUDIhm1c+vRldXV8TJfdHoOVBVFQcPHsQrd96AmXcti/n6lSd8F62trbjog79GPN4zQUCD0zNJ8Mr0/8MFG/4U6kvhdDo5cMswFoslaRfNmdKbIBx/34jSS6naASklHAkmCYDAe4jb7caePXtC0xWam5vjShS43W7YbDZ0dHTw+isHOJ1O7N27FxMmfBoxlYSIMgN7FAwCl9/pn6qqoSWQaqtrsHjBjJjb2my2Xr8b4QOAWBcFPlWBXwp0dHSgoaEBL37p9j5jenzyN+BbXYmtrc+g3vNq1EZ81JsKtdfPasVx30Z9fT0eHXMj/GsCSaB5B5byhJ9BEmkwFo9MfP/mEolE6We32yMa1cVr586d2LlzZ8TfbVlZWZ+vkVKioaEBO3fuRFNTE5MEOURVVbS2tkY+xmkHlC0kACnS86GBzKofzTKZeMFstVpRUlICq9UKg8GQ8DrFgxGeEACAufsWQwiBgwcPhraZX798wPuvqqrqNe2gtroGi0dfB504+n/Rs6IAiJyS4HA4sHjBDOh0OgwbNgwbpq4YcEz55Cubrun1mM1mAxAYqD33y6/B/WIgWXDD7oUYO3Yshg4dGnOda0qPZL4HCCEy8gKdFQVE6VdUVISJEyf2WhJ5IDo6OmIm/Hw+HxoaGnoNJil3DLS5JRGlFpsZDkJwLd9MEmtpwJUnfBc2my2lF9Q31wWmBfzvjJ8Hqi3qAz8jj8cDnU6Hm/Yv6fP1JpMpYhBiNptRs6sWj036OpxOJ/x+P96feU/UqQTB5ETw87kPrI1IKgRfE9zOYDBgUsllcLa5YRC8+x0PtUc288ljbgktSQkAbW1tMF109Gd+3ttHkzPB/0NKv2S+3+p0uoxc7pKJAiJt6HS6pAzyXC4Xtm7dCrPZDKvVCq/Xi+7ubuh0uoy81qLkcjgcWodARFGwdn6ADAZDxp28+rpre9VnD4Y+XzjqhpQka4KD8Lq6OtTsfQxGHXDm67+O2GbVSbeira0t4jGj0Yi5dz+HG+YsjLrf63f+N/BJfe/nghUKT0z5JtxuN3w+HywWS9SGh2tP+ylmvPvHsEcCZfTnDN+JPwzbFM+3mJe+tuer2G/rXRZ67baH8b8zfo6vvvP7fvcR/D8MT+hQeiSzmiNTK0OYKCDSRltbW1Ib17pcrogeKPzbzg/d3d3weDwwGo1ah0KUMJEb97+jYo+CATIYDFqHEKIoCgoKCjDvwNKjjwkJoz76nb+b65ahqKgotTE9NwS+1ZV4d8ZvAARWNOh+vbJXkgAIdD5+5GcXwLe6Ev6VlfCtDnw8dey3Yu7ft7oSq0++LfT117b/B3P3Lcb8+uVHEws9RCYJjlKhsMtuDCrUXkmClSd8F4vHzkVtdQ3279+PZ7/w/bj3Zzabkx0i9SOZyxgyUUBE4aKd04kGIjiVEeDKB0SZghUFAyCE0Lzrt9VqRXFxMS7+8G+hx3435Rl81RK7qVd4I7prtj6E/53xc9TV1SX9IltV1VDTwq1bt2Lx2LmowYt44sbYjQwB4IkfXYqSkhIcPnwYANDV1RVxB7q0tBSX/+4ptJ2g4p1fXIvW1lbUVtegqqoq4ucABO5c//jMv0M6nWhfNQYvful2NDQ0AAj8/wWnSQDAmw0T8MVD/w86MZv9Cno4feO1vR7ruRRWeMng6ycvg6XHVI7g79368+/Gzp07kx8kxaTX65M6VSBTEwVsZkiUfl6vNyN7lhARpVX23/+OiYmCAUh2F/FERWsIqFPUPpMEALBh6oqIZEGwZHzZhJtTerL3+Xx9rnYABAY0N+wOTD149gvfR0tLS6/Kk+AAdchnCuznH50bH560WXfWL7Bnzx4AwOHrjgcALBszE2azGRUVFfB6vbj6838djS1suUYfAHWqCoU9PgEAM7ZeGvF1rGkDX9v+HwDAmhMXwSIKez2vU1T4VQWnv3onpx6kmc/ny8jlDJONFQVE6dXR0YFDhw5pHQblkK6uLgwZMiRjE9JE+SgpiQIhxEwA9wHQAXhESvmHvrbP9qkHWsfvlyLU5X9K2WE8OubNuF/bM1kAAOPHj8e+fftCyY/59ctTMqATQvT62en1+kClwMZ/hB677JP7AADLJ87vNcBZf+93cPoP/4UJEybAbrfDbDbjrHV3AwCaDpWiuTnQm6CkpCSw/1nNMBgMOPet30Xsx/dMJaAAK34yK+KO+BfvAayXNuGdk1Ym6bvOXl3uo9MEYv0+BJdBDFRi9E4SAMA7J60M/c5ZLBY2NUyzZL5faf3eFwsTBdElem4mipfX6+XfHSVVd3c3du3aheLiYhQVFcGidUBENPhEgRBCB+ABADMQaDf3gRBijZRyy2D3nam07vq9eHQNvl6/FOtPfnpArw+W1wcHb6et/SWeO+UHoQFcqu76hpf7x2PYsGHYv39/6GshBM5adzf0swIDA4/HA7vdjhXHfRtX3PM0XrjtAnR1dQUqLuoB/azA62p21Ubsd+n4ecDtwPcv+BccCyI77S67JbBs4mH8AENx1oC+z1zxxsmP4exN10d9Ljh9462TH8eGqf2/jQQTVGxqmH5utxtGozHuXgVCCFgsgUs0v98fqjbquSpJJuGApbd8PDdT6gXnjrvq6jSOhHKRx+MJrZRFRNpLRkXBqQB2SSn3AIAQ4nEAswDEvBjJ1LtS8Ur2vN9EKYoy4CRBuNmjP8GKA18AEFgP2el04pqtD2HR6DkZceEdnBqx8oTvoqOjA0OGDAGOXJscPnw4Yq784ltnhH6vFo+di5mvP4eh4yKbLP3vjJ9j//79oQHTn5/7etTj+v1+eDweTN8yG0UmF9Ye+1ySv7PsYBJHG3aGT3dZd9YvAk0J6wCD4OylbBDvRZfJZILf74+oslEUBQaDIWOTBAATBTEkfG4m6o/P50NLSws6Ozu1DoVyjBACEyZMgLHjJKBD62iI4pfLqx4k4yp/JELDNwCBOxdfTsJ+M5bW86d+1PxvPN97tbqE/XjIbny/bDvO3HQdzn7jN6HHg1MRBpsMidZLoS++1ZXwGwHTRZFLG1712YN485w7Q1MMgN4N9RRFwZgxY6CqKqxWK8r3tgMA3p95D0596Q4A8a3TO79+Odw+HXTPDwFQiYduvwxAfiYKgEAlgFK1I/QzBIBz3vxt6DnKDk6ns99pH7F6GaiqmtFJAoCJghjy7txMqefz+SCl1PyGCeWesrIymM1m8N2cKHOk7XagEOIWALcAwPDhw9N12JTQ+uTY6ihI2r6i3REODsgHWx5eW10Do9GI6+59HvpZzVG3ca6thGVGc+BYC8LiMhhw/d9fCL0uPEnQk8FgwKhRo0ID2FUn3Yr2HeUo3SZwKo4OcK1Wa5/x6vWBn8XzU7+FznGdkFIGBk6FQK1tGOYXN8X1fecatXEyNkyNXDWjwJj4wHHViYtwxafzAKSuDwbF5vV6o/YJCRJCpDkiygTh5+bRo0drHA1lOrPZjOHDh6Oqqgq7du3K+CQiZY+CguRd2xKllczd66dk3Bo/CGBU2NfVRx6LIKV8WEo5TUo5rawsCbfDNZTMdckT9c1DS6EkucYlkTvDiVYJeL1erP3t3KjP1VbX4LnvXRWx8kD46xYvmBHXYLKoqCiUJAAC6zqv+eoFAAApAd+qSihLK3D2/z2CuQ+sRXl5eURViMFgQGlpKUaNGoUnpnwTHR0dEYOpLS0r8fCeM/Ht+tPi/r5z0YapK0If/zvu2YRfX6WLbHaY7QnDbOPz+UK9B6LJ5pURtK7yylAJn5srK3u/FxNFI4SAwWDof0OiOAWXuQ32wSAi7SXj6uoDAJOEEOOEEEYA1wFY09cLsv3OVV8X26mmU1S8dOLStBwreIc9XLRBfbji4mJUVlaipKQERUVFmDBhAi764K8R27i8ejw65kYAwJV/WNnv0om11TXwra6E+6Xoxw6/WHn5yz8Jfb54wQz411RiyW0XoGj5u3j57jlYvGAGHA4HJk6ciKKiIgwbNgw37n0UV332IM5963cxfzdrq2uwsWUkzvrsij5jpb6FJ6V6/l5Q6jkcjqgX9xaLJat7xzBREFXC52aieNntdtjt9v43JIpTNierKY/JNH5oYNBTD6SUPiHErQBeRmAJplop5eeDjiyDaXVBXVxcjDcrVgFpWjRm7r7FeOrYb6Grqyv0WKxBfcxKg629H9K/UAb/An+f+wtte2Qe5KqfX40rfv80fKsrobs8chrDJR/dC9/qSuhnNfc60SxeMAMlJSVo/dbpaGoKTB1wOp34ymu/wjMnLkBzc3OoamHKlClobW2NefHz5DG3BKYvqKv6jJn6Fr5E5/z65Vhx3Ldht9sx70AgAcYpCallMBjg9XpDXwshNJ9ONVhMFPSWj+dmSj21cTKUqh2sJqCkM5vN/W9ERGmVlB4FUsoXALwQ7/bZXlGgxZw8g8GAYYZzkMa2EgCAa7Y+BAB4+vjv4OrP/xVzELdo9BzMO7AU68+/O1SJEN4ADwA8fh2U54bgld/ciMbGxl77iJVseHfGb+BwOKCf1Qzvmkr0/PVZPHYuavAigEAfgtbW1ojnOzo6eiUkaqtr0N7eHvpaURQ4nc6IAVRPwTsozeIZHFt+ZcztqH8bpq7AWZ9dAY9Pj9lb/q11OHklWN4ZZDQas36eMRMF0SV6biaKl8lkQklJCVc/oKQxmUxah0A0MNlbkNkvXl0NQLqnHhgMBty491FcvO2KtBxvxXHfxlvn3hXx2NWf/wtAYDAfzPqGD+xVVUVtdQ127Ah0yA8mCVraC+FbXQnf6koMu3oPyh9aD5vNFvW4tdU1oUREbXUNloy7Cc+cuACnrf1laKlEw+W9myL6fD7875558K2uxIx3/zigRJSqqjhw4EDo++xLNpdoZ5I3T1iV9H4b1D+32w2TyQSr1QqTyZT1SQKAiQIiLQwbNizrb/wQEVFsXAR9ANLdzPDGvY8CANYem55l+oQQ2LVrF5ZPnB96TKfTQa/Xw2Aw4PKN/4jYNnzgHEwYBP3w4l8DAO7dfBewYAYqKirQ0tLS5/GDr/d6vWhvb8ei0XMw5/6XIcXRRIGiKBFLooVPj1AUpddd03iV3+bDrN+uxurjZ/W53fSNs7k8YBKsP/npiNUUKD2klHEtF5otdDqd1iEQ5R2j0YjS0tKI6jyigfJ4PFz5gLJSLt/z0uQ2TDZnoC0Wiybzea2G9CQn3C9W4vI/rAgtDRj86O7uRmdnZ8SA/OUv/6Tfu+v3br4rkCQ4YqB3+1f8ZFbEH2LP44YnDQaaJACAPz8zt98kAcB59JSddDodrFYrpJQ5NbhmRQFR6rXq3oHd+mHEY0ajUaNoKJcoioLCwsL+NySitOLVVYIGMwgdiPn1y7Fh6gq8dnzqmlVfuO2S0OdPfOciLPlO9AaDBQUFuPTTx0Jfd3d3J3ysyz65L/EAcfSOof/IWqU9GykVFhZCP6sZa0/7acRr+jrxJLrUYz47fdPVKdv3hqkrMGPEtri3n1+/nP93AySEgMPhgNfrhaIoOZMsYKKAKLXs1g/R1NQUcaPE6XTGnEpIlIiqqqqI6zqlakfEB1FGy+FVD1hRkACTyZT2aQfpmMPd6Trac2HuvsUxL7otFgt0ior3Z94DACgtLU15bIqiYMSIEaiqqgIAyDUVAIBRo0bBZDLBaDRi+PDhuPjDvwEAZrz7R4wZMyY0TeLabQ9j9OjRmF+/PLBiQQ+DGXCe/JfvDPi12WSD2wdVpvZv9jdDP+vz+fDkQHgvC0pM+Huv1+vNmeZRTBQQpVYw6R6csuRyubBnzx44nU4tw6Ic0V+lLpMFRNrg1VUC0n0xOr9+eUoHaIf99qjzw+cdWNprAGE0GjFs2DAUmj2hRoXnvX0PiouL4z5evINyg8GAgoIClJaWYvz48bDb7di5cyee++XXQtuc/cZvcMPuhZizZxEu+uCvEa//6ju/x8SJE1FREUgqnL/+DwCA63Y8guHDh8NisWDIkCEAgA0X/HbA5W6FFzQN6HXZZoQucCGYrl4CwaTA/PrlKCkpCf3eLB0/Ly3Hz2U938NypTEnEwVEKXb4GABHqyqbmpqivn/o9XqMGzcOU6ZM4XxziluunIuIco0mzQyzsaJAr9drkjlPZcO8yz+dByBwh/aq1WtR+sWjKwrcsHshnjzmFtjtdgCB7sZffvn/9drH7C3/xuqTb+u1JGH43V8ACV0wGI1GfG37fwAAT0z5ZmiKwxWb/wmgMq59nP7qnVEf75lUmP7KLwAAL0z7UdQlGwm47vN5oc97Jgs2TF2B+ztG47bSA4M+zl+PeRK3b7s24rHgKhSLx85NezVPrunZeBQINI8Kr7TxeDya9GAZrFyZQkGU6RwOR8xmqEVFRaiuroZOp4PaOBlud+qmTFJu6e89XG2cnKZIiAYgh/NcvA0TJy0a9jj+F9+gOBlWzpoBz3ORxwsmCUwmE2a8+8eYr5216X4MHz48tORaeOXA5MmTMb9+eWjgD/R/96+7uxvPf/GH8K2uDC3FCAArT/gupACePnEhNkxdEfHx6klLE/p+e7r4w7+FpigMHz4cw4cPj0huVFRUoLy8POI1MsXl+Jni9ZMej/nc9I2zsWzfqUk5zhnmo78X78+8JzTF5bFJX8/KwWsmMRqN0Ol0vZItfr8fDocj9CGEyMq789kYM1E28vv98Pv9UZP/BQUFEM3HhgZ1fN+meMVapldtnMwkAZGGuDxiHIQQcLlcaT+u9avN/W+UBPPrl2PR6DkwXnr0eOFzwMvLy4Hdgc/DKxxUqDh9Y+AOcM879UFfee1XvR4rKyvrVYHQ0yUf3QugEgUFBWhtbYUQAhUVFfjozn8BKOq1faFiDsV2d8uxeKH++D7332G3oPB/gQaIQcEpCuHfy4YLfguv14szX/813p95D8rKyuBwODDz/b8AyI9EgVf238Dz9E1XQ5Vi0BUwM0Zsw9pDx4SmtwDpX440FymKEtfP0ev1wmq1Zt3SiUwUEKVHcXEx9Ho9LBZLqJHhcRVXBZ5kXoAGKPymUBATBJQNhMzt5RE59aAfer0eer1ek0RBOs070PuOfKgyoB4w6n1484RVEc8rUEIDQ7vqwvmb58Tc//sz7wkN/mZtuh9A30sM1lbXAAsQ6pXwjYNL8E75yri+lzsrtuKG0g9ww2fzIh7XLyyH1yqw8PYLAg8cE5hSceGdSyMSBkvHz4PH44GiKDhw4ACu+uMzACpxKu7AMycuwJWfPhDadvrG2SmdHpJK53w+Cy6vIepz78+8B2rjZHzg9sIcxztgsJdGcGrCQH8mP6n4AGsPHRPx2E37lwAI/E70nNJCfdPpdDCZTAkN/MOXGs0WTBQQpV4oIYAdoeqjY4ZcEXN7g8EAr9ebltgGSwgBi8WCkpIStLa2MkGdZlwakSgzcdWDfuRDkiCWJeNuCn2+7oS+B+nBO/qvnLQk6koNp750R6iUPF4lJSU48/VfY379cvjVxH5VeyYJSi7ZjYKnNsBvjvzda2pqwlM/vhy+1ZXwra6E+8VKzN4eSJqoqgq73Y7FC2Zg6W0Xora6Bu3t7aitroF3TWD7bHXZjpkxkwRBStUOGIQft+28LuH97/N1DSiuBXUzoz4eTAz4VlcySRAni8USmloQLyFEzBLQTMZEAVH6qI2TMcR3etQkQfiSdmPHjs2Kv00hBMaNG4fx48ejvLxck6mm+e7AgQOcqkLZS4r0fGiAUw/6YDAYNO3Emso71U7Z92Cg5woFSpw5JZPQx1ypIVhRMGROC/6y7nv97ivYE2CwP4fa6hr8UP4aALB4wYxezzudTiy59QL86Iv34J+f/irqQKnnXdYl350RqkaYjtkoMTvx8jHPDyrOdGp2xM7eBxM601/+OVQZu0qkL9d9dvOA/t92tgeSLy+d+mN4vV4oioJLProXpaWluOqzB/HEj27OyoGsFgbyczKbzVm33JkQIquSz0T5wmQyYciQIWhpadE6lD5ZrdaI0veqqiq0tbVBCNHvNElKDrfbjT179mD8+PHQ6wNDE6VqB6cfEGks81O9GtLr9WkdlFgsFgwdOhRVVVUYPnx4So917qYbEtr+JWd8GfZzN/d99/mtc+/C39/+Ub/7KSsrwzlv/jauY/Z0+qarez127+a70PrN02O+RkqJv37484T+vzs6OgAAvlWV6HRZ0rZ84GBdtiP6XfugYEJnw4W/T0c4Ied9fnno85nv/wWXfXIfVFXFwlE3QFVV+FZXhpbm6sv8+uW49OPncXPd8ojH8k2+LDeVDXcsifJFz4FdNkw96O7uRkNDQ+hrs9mMESNGoKqqCgZD35V3lDwejyfi/4Eoa8g0fWiAUw9isFgsaUkS6PV6DBs2DJMnT8b1O/+LSz/+Oy7+8G8xmwMmQ/iAtra6Jq5S7l9tvxxnbL6qz22mb5wNj18XKuMvuXgnfKuOlud7/DpcVnRzv+VlFosFVVVVAAZWTRBe0RD+vS37wcykDhiDv8drfnFN6Hv2l3+OMzZfhekbZ2P6xtm4cNslSTteMpz56ZUxqwl6Tg0JbyiYqKeO/RZUJDbX3eHtnYy67JP7UFZWBpvNhsULZsRVmuhbXYnnTrkEC0cF/u/n1y/Py+kKwbsyicjG0k8ujUiUOZSqHRFfBxseZrqOjo5elYNCCBQXF2sUUX7q7OwMVaCwmoBIe5x6EIXRaExL+e38+uV4d8ZvcNraX/Z6LlXTDnrebY934Lx84nx4PB7s7f4mRljPh0lEZtmD+23fU4Zng+X9C2agvLwcl9z9OPSzmrF0zNeAj/s+TklJCa7+/F/AzsH/DJZNiCxT9/v9SR0wulwuLF4wI9DL4Kt2vDD1emzfvh3/GTEHt9z9MqQeePDXl+O8z3V49fhVuHHfeVg2dl3Sjj8QXv/RQdWGqSsikkaDSQz01NXVhe321ZhSPqvfaSvtqgMXbZ4LADh8uARD3jXi5bvnwGKx4Ly378EVm/8JIJD0MRgMsFgscDqdUe9UzX1gba/pJfmYJAACA+hE7+Z5vV5YLBb4fL6suBMIsKKAKFMEkwTBAZ4Ytl3LcBJiNBqjvpdUVFSgvb09K5u8ZqvGxkbo9XowRUPZIpdXPdCsoiCTqwoGcicuEWazOTRA73k3TKeoKe1NEKt/QE897y67XC6oqgqn04km9+u9ttcpgZNo5cTI+Xw6nQ4f/+uHccfX2dmJtaf9FKdU1sX9mlhu2L1w0PuIh8/nQ+H/CiOaXj5854X4zx0Xwu1245/D5mFn+7OaJwnSTUqJr2y6pt/tzEKH92feg/dn3oOhQzux5NYL0NTUhH379mHlCd9Fm80KIJDUunHvo5i95d+4ce+jqKysjHgfURQlYvWKfDfQC9tgEsZisYRWHclkLA0mygzha94rVTvQ3t6eVVOgosVqMBhQVBRYkjl4vVZQUACr1ZrW2PLN4cOHsyrRRJSrNKsoMBqNaSntNxgM8Pv9MJlM8Pv9fS55YzQaodfrU7qGuMFgQM2uWgC9B+MAcMawvQPed3At+54UIftNEKw++TZccvfjABB1sCWECJ1EHQ4Hztp1RcRyieF3qufXL8eqk26FxWLBhe/9GQCwcNQNcV8weDwebGypBka+F9f2fUlH2bnX68WSWy/o8/vz+/3Y2voM9liuxyXWzF9FI1nVBfEkpi747Dp4N92Bd2f8BkDkxVpHRwdeOuU6XPO3Z/HindeHlvs7f/0fcNkn9wEAVp7wXXg8Hly34xEAQHV1Ndrb20N/+11dA1uBIZtZrdZBv48Fq6rMZnNGr/zCDuVEmUmn08FoNGbFUoNutxs+ny9q4tFsNqOzsxNDhw6Fx+OB0WhEUVERGhoaYDab0dzMBHUymUwmjB49GrJpitahEMUne/KhCcuLRIHX6w1d9FqtVni93lBZrcFgCG3j8XhSfkK7ce+joc+jDcbebJiAGW0jsfbY5+Le506vHTd+Pi/m8+GDtZa2QpS+ZUH5Q+vR+q3TsfS2C6GqKlpbWyHF0fKZ1kPVAOaGXldcXIzOzs7A/lQVHp8e0zfOjroUIoBQuXhQvEmC8vJyVFRUYP3JT8e1fTQ9S+pTLd4SbSklJrgeB6xXpDagPhj1Pnh8gT/78J/R8onzUVBQgFmb7k/6MXd67ZhkiL3KgkHxw+vX4bS1v8Si0XN63Ql3uVxY8t0ZEZ2za6trUFBQgK9t/w+u+uzBiO0v2PCniK+fmPJNdHd3J+E7yQ7JSBKEc7lcGZ0syIaqB6J8ozZORkHFlqypKCgrK4tZnVRYWBjaBjhaFTtmzBj4/X74fD60t7enLdZcZTAYUFFRgbKyMiiKkmCXIyJKBc0md6br4q5nl3SHwwGv1wudThdKEAQfS7XgSaY/XW4zpm+cHbUZXM9GQQB6JQnWnvZTPH38d+BbXQn3i5URz71z7s1YetuFuHfzXaH59UHP3nG0TDw4Zzzo6s//FfG1b3UlPM9VQpWi37vGi8fO7fP5IEVRUCnOTHoWOZOaER0z5Ip+l6ZMpfAqkHA1u2pTcmf2hWk/6jOJBQCvHb8m9Pm8A0thsVji2nd3dzdqq2uwaPScUDPJ7nWVvSpIRo8ejSFDhiQcezYSQqQkAZvJfQBYUUCUmXbv3p0VvU6CTaVjsVgsqKyshKIoUBQlYsqbTqfDyJEjQ9MTKHFmsxnV1dWYPHkyysvLM/p8Q9SLDNxkTceHFjT7a0zXxZ3b7Y46l8zv96f1BKbX63Hlpw/EvX1tdQ1Ofm8O/tg2EQBidpBf64wsCvE+W4mDBw+is7MTixfMwOPfnonyG9tQcvFOLBx1A1pbW2POXb7qswdD0w6iVQrMr18eOkEuXjADih9obikKDNKeqYTz1cper3G/WBl3J3WDwYDTN16Lt5Jw49KoP3rM2Vv+PfgdJslOrz3hpSmT7fWTl0V8veqkWwEgJVNufD4f/n3c0n63C+/Lcf3O//Z50daTqqpYvGAGFi+YgSfmBBoZ1lbXwLe6Eu2fVOK0tb/EFZv/GVpJI5dJKaHT6fLqQosVBUSZZ5ftuaxIEgDAiBEjBt2bqrS0NDnB5BmLxYIJEyagtLQUsmlKqM8FVzwgygxCi7KwadOmyTfeeAN79w58Pn6itJ4nZzabMW7cOHzp1n9E7QHw/sx74HK50Nraio6OjlC53twH1sJrASwX9D0Hzrc6MEhf8ZNZAx7w3bDvCZj0gQqMYQVdaOqOniEP3rENVmT0ZDabce1fnsXiW2f0eq4vBQUFqDKf12tFhYH46pbL0O05OoDQovN9sGHl81/8Idrb20O/fzqdDlPKZqU9nmhSNUUj+PMuKyvDcN25cb/ujM1Xwa8eHeQO9v9NURTMuf9lAIHeG7m+AoLJZIJOp4PT6UxqyW+mTj0QQuC4444LlgJ/JKWcpnVM2WzatGnyww8/TNr+xv/jr9h17UNJ2x9ln62tz2T09IOioiKMGTMmKfuy2Wyor6/nCgkJGD58OMrLy5kYyBDRqpYHK9fPzeaRo+To7/4oLcfa+Ysfpf1nmfMVBZnC5XKhri7QyT9YJh306uk/w969e7Fr165eXYKX3HoBDE5EbN9T8LnVd8we1F3hzvoSONcG9hUtSdDzXB/rboHL5Uo4SQAEBiPJSBIAiEgSaKW2uga11TW45KN7MXbsWIwbNw7l5eW4af+StPZQ6MuGqSuwYeoKPH9SoHdGmSW5VQUejwfTN87utSxnLO+ctBIG3dHpQmazeVDHV1UVy743E0Cg2qaiomJQ+8tEBoMBVqsVer0ebrcbDocj6RfmmXqhbzKZMnoFHaJ8l+mVXOXl5UnbV3FxMcaMGZNXFV2DlUlTQ4moN83ezfR6fVrfTIOdarVkt9uxeMEMLL3tQgCBAf7S8fNw4MCBmM3WpJShdeGjJQu8aypR/vAGPPGjS0PNBgfMpMLQxzixua4sZXdkdTodPnRemJR9PW6P7AXx7Be+n5T9DlRtdQ2+8tqvoNPpUtIsMBnKlQJsmLoCKyc/k9T9Bn+v412WEwDeOvFoDDW7agc9EAz2KRFq7pSpK4oCq9UKo9EY6rMS7xSfgeh5h0xRFFgsFlit1kEncwZD6/d0IupbpiYZg3r2sRqsgoICjB07lsmCOCiKAoPBwGoCogym2TuZECLtF3mDnYOWLOFzquOdDrF4wQws+95M+FZXwukxwOkxQF1RAcUH3PfpXUlpYPbcly4G0DshIWXgsSGfpObnpygKRo0albRlA/++66sRX9tstqTsd6CCSzTu2rVL0zjiYRHJH0i/dOqPB/X6m+uWobS0tNfd4+DnBoMBJSUlfV6YBZNtDQ0Ng4pFa2azGWazGaqqwuFwpG06lc/ng9lshtVqhclkgqqqcDqdcDgcmt7Rz5XED1GuGuI7HVVVVZomFMPp9fqIu9ipSLBarVaMHj066fvNNYqiMElAuUGm6UMDmqY8032Rl47lGFPJ7/dj8YIZKFpWjMfGX4NFP7gAj35vRlLnw635f9f0esy/JpA4CA62Bmt+/fJQ4x+dTof/396dh8lRVvsD/75V1d1V3bNvmTXJZIWwIyCy7wZUQBbFEJZE9IrIRXGH63W5Xtyu28/tysWwmYiKCKgIgoDigiwKyGZIQkgmIWSZTGbpvev9/dGpSvdM71v18v08zzxMd1dXn+kJU12nznvOlya+YY8fKgenf+9WFYb14ST8m/TLSOpRIZUuic0NgXijzYvX34wVm1dj7ty50DQNKzavxv77749LXr0V57/wA8yePTvrSWutrh21ruAHg0FHegVIKREMBuH3+2f8/2Q1jPX5fFBVtaJxsaKAqPq1t7djwYIF6O527thnGAbmzJmDxYsXo7+/376/XH+zmpqa0NPTU5Z91wtVVcuyJp6ISsfRS+yV/pAXi8VKPmPcCTd+pjQl+qnEJx/su21VF/z8Y2cjEAgUvX/rRO68579v33doV6RkWeXpa/+rpXmd9XPfPHQx5L/F04Iv7lwGXdexbN2qGSfGudoWm8S5/7wcipA4vf9lfL77hZLFXAwhhF1yOjU1hT+f+nlgV34/4+OH3pmyl8Mpf7rB/v4tD34GTyy9AaZpYteuXUmvm2jlyBrcdlV1/FvIh2EYkFIiGo2W5P+/crCqG6ylEJWMkxUFRNXv5ZdfxvDwMHp6ejA+Pl7x5H1LSwuGhobs47CmaViyZAnC4XBZY+nq6sLY2JijjbSrWSwWq/qlKUS5cGp0YSU4mihw4kOe3++Hx+Nx/CpzNZpeGhi9pxu/v+FybNmypWQf/hNHVQ63juInww+XZL9A+Tr4l4KUMuUSiHlNZ+HxQwvbZ+LPa0qBB7bsj7WTs/Dqng4AM6/KV9KKzauTkjRvvPEGznv+gpLHtOfJbuw8Yid27NiRca1ptSSMClGN0wam03Udfr+/4slfVhQQVT8pJSYmJuD1ejFr1ixs2rSpoq/f09Mzo9pMURR7KVe5WMsqN23aVDOjIispGo3C7/fD17uWSxCIqpSjSw+c+pBnlR9ba24pbtm6VTPu2717d0lfw+v1QhESjx96Z0mTBInGpgxE7+mu+pPD/brOzXkaQDZXz4+/l1aSAABC0tkPJtZ4SADxqyoxFY+HSrce9L4jrsU9F56Jbdu2lbwhVbWohSSBtSQCQEWvnKmqWjV9Z4goM5/PByA+jrC5OfXo5XJxsrGgYRjo6+tz7PWr3ejoqNMhEFEGDdWjwBKJRKAoir3mlt1p9x3Ep8tnmYbL5UJnZyfa29vTbqMoCv5yyC/yji+T89efbl9dlxJoeqipZP0UyqWpqQnHPPOuvKYBJJpePfGd9ack3Z78YzfW7/oV/rX7HkcTBonJgp/MW4bLn1qBx3I8933nujNS3v/QMZ/C7cOXYdu2bWXt9F8NpJRV0wQsnel9H1yu0ow4zYbLDohqw8DAAHw+H6SUEEJgcHCwoheKnK4gZeVTek7/bogoM0fPkFVVrXjzK0vih9tG/yPudrvx7n/934z7//yND+S8D1VVccmrt6Kvrw/v/Of3kk4QE5XjxG7LRKv9feze7qpNErhcLng8HnR2duJdL98IABhqGct7P9mWWKwaXIafLYu/B7FYDGrnv/J+jXKIxWKIhlV8/OXsS0RMmHh9cuZ85V8edFXDlXFWcyJTCDHjg16lrvI3+t9tolrRGnozhBCYnJwEEP+8UMnGhpOTk46uheffqvQqXV1CVBacelA+1XBVqJo/iFdCupOuE//wXzPuS9dV3urue9T912V8rVKeRHxh5/5JJ83Re7px+4dSX4WuBpe8eiv6+/txzrPfARDvIfDzeQ/ltY9ckgSJVFWFNnpgfoGWWOK/ma72SYw+25315zjmmXfNuO/ugz9U8qUwtaCaqyZSVTtUarJENRw7iCg7q7N9YmO/1tbWil0o2rVrF15//XXHkgVWPwSaic0Miaqb4ws83W6341MIanVkWqlIKfHG1jbM6h9Luv9Xh12DHTt22LdXjqzBrXMumbEeXFVVnPnk1+3bUVPBbbMvStpmSdd5WD/xG3TGji1JzIknmoGHuvHsV6/B+vnrq76M7eTH/htA/o0Gs51Y3zrnErS2tuLc576LNQtWIhaLwePxoL+/H7ds7MHlLdtzep33jxyTV1y5WLF5NYB4EmPV4DIYCw2c87/34mgk/0yd3in8dMEvcdpzy+37YlJAFRL3HHI1du3aVfLYakE1d8xOlTi0xiWW++86r9LVgAKXVlF9sRrVDbgAjAIm4smDnp4ebNu2rSIni6Ojo1AUBbNmzZrxd8taElFOPp+vJnrOVJKqqujBCTC3OR0JUREkpx6UVTVcFarmD+KVMj1JAGBGQiD4QDcue+vtM65ae71ehGMq3Ore7X/VCVyVvK8Xd96FlSM3w6W+E48d9MuiYg3IfcmAwIPdcPnjVwyqOUmQuBRDKeFflB/Puxz9/f3YuHEjRkdHsWbByuSmlC8DwAm4PMfExHM7+7NvVKRAIIBHP3kJzvjM7dDO2ZeI2uX3JSUJnlgaH4MYjUbxr39Vx/IJJ2iaVrVVBU7+7ayGYwcRFcbctgidvWvh8/mwcePGivyN27lzJxRFsSsg9+zZg82bN2NoaAitra1Znl2cSvVuqXYulwsdHR0lu2hEROXFRAHiFQVut7vhEga6rqecdGBJXCbQ2dkJ/a07Uk4S8Pl8UH7dAZyzA5F7u3F7ih4BLS0t8Xn3RY7AuX2iC99bfxIAYHTci9//+3mYmprCG2+8UdR+K6WUlQS3zrkE4XAYGzdutO8r5opFJcdLbtu2DXd+/Bxc8LV77GTB5B+7oe9GUvIAiP87tKoSAGDNgpUNcWXGMAxEo9GqTRS4XK60y5bKeYVQVVX7bzYR1S5z2yK4AQwMPI3XXnutMq+ZUEE6NTUFIN7DoNyJgnJXLNSK3t5eNAeOdDoMotJiRUH5VMuHvXA4DF3XEYlE6nbUmsXlcuGSV2+dcf85Q8/hns0H27etRIGiKPa6+ukURUFra6t9cnfHNWelPHkIh8NFJwkiMmonCR58yyexefNmTExMFLXPSlg5sgazfBO4Z+EDeT3v2OfOy/h4c3MzxsbGZty/anAZmpubceFLP8z5tb64c7+8YitEa2sr9uzZY9/2+/247arT4Xa7EYvFEFsWg9vtxqJFi3DU/del7Xcxa9asin2odEpi6X61Nm7MlCgo13Iu631xu90N31uGqF74pt4ETbu3IgnRxL9ZVkKznMtPpZTYsmVLymN1I9E0De3t7UwSENUYxz9peTwexyYfTGddpazHpjMrR9ZAURSsHFmTMklw90G34NOda5OueFulcp2dnSn3qSgKZs+ejWN//1n7vnQnDtZ7++4NpxYU/9vWnonjn93X98Dn86GlZWZX/GqVb5IgIEOImZn/9zzv+e+nfayvrw9/e+t/5/RaRz9zAX49Uv6Gh+e/8APMmjVrxv3hcBixWAyKomBoaAg/XZf5g4Su61VRiVQuLpfL8b4tuahkEyq3253Uz8YwjIq9NhGV36K2s7GkK3NyvBSsKgJg32eccv0tk1Li9ddfb/gkQWtrKxYuXIhuebzToRCVRx1PPXC8okAIAZ/Ph/HxcadDARBflx+LxSrSjKuSrKvMqcSTA01Jt49+5gK4XC64XC684x/fnvEcTdNw6cbboGyW+MuhP8efgwo+/vIFKcci/uqwa+In9XuAn877fV5xH/Ps+TBTNMTSNA0XvPi/9s9WrVaOrMl7uQEAnPzsxTlt19TUZI+cst77VYPLcNzDn7O/d7vduGX8j0kNDSMyihOfe3fK97ac3vb0N9P+voaGhvZO2kg93vLh467Dxo0b675fQa2UqGaqdAiHw/B4PCXpG5Lqb7HP5yt6v0RUfRKTBS/uvKugfbhcLrjdbkgpEQgEkhIBidUDLS0t2LlzZ3w507ZF9nSGUtm1axdGR0dLus9a09HRgf7+/qIrSonIGY4nCoD4aL1AIFBQia0QoizZYL/fD8MwEAgESr5vp6RaUnHLAbcCmPmh++6DbsEJjybfd8eiKxAOh+H1eu2T9L8c8gsACo7X4wmGd6xdih3+pqTnveMf3y7oZBlA0ols1FSgKSbuXPIBHHX/dbhzyQeqJsGUTvjX3cCh+T0nn14B73r5Rtw291K7ZHP6SfjKkTVYNbgMZ3b+HMCJ9v3HPROvznDinNRagrByZA0eOf56exIERjI/r15LzYUQ9hXyWCxWM4mCTKSUJfm7nK66i4kCovq3pOs8bIn8HgOufZWIqZIHPT099vLRlpaWpCWtmzdvTlrylvg3Rdd17Ndxrn3bOpktVcKgpaUFu3btQjQabcgxgLquo6+vj0kCqmsCnHpQdrquY8GCBRgZGclrzbmiKHbpWFNTE8559jslvbocCATqKlnwrpdvTLp99fyHsZ8r9QfuXrUJqmLi6nmP4KIma3b9nXhGC2KRW8fjh6Z+jV8tur9k8R7z7Pn297886Crs3r0bK0fWYHx8HNG7u3EB/reqqwkA4I83vBfw/yDn7U964Zy8X+PSjbcBSE4SRH7VDdc74n0jWltbMUvsSxJ8Y/ewIwkCy/kv7Hs/7CRBDuo1UWAYRs1VL+Xyd1HTtKIbxEop4ff7kxo6appWNb1tiKi8EpMEwL6KAythsKTrPMAElMF9J/eJJ6Yu1x+h63q8T5JporW1NeuJa6rHC0keuN1uLF68GKFQCOvWrWu4ZEF7e3v8Yp7TgRBRwaoiUQDEO1kPDg7ilVdeybmhjWEYaG9vx+kfWQXx7p1Vf9LopELW8//54JmZ+0PdlevfYFUT3H3wh1KW743/tRu4sGLh5G3lyBpgBGmTKqkEI4WPUEos0X76O9fg6N/9BwDrxPwCvGvO0/jb7nl4bby94Ndw0o4dO7JvVGNqpR9BIiFETgmAYidT6Lpu78PtdtvHBZ/PVxdVF0RUuOn9DBKrAZTetfbtHpyAniZAzPoX1q9fH/8stCv/15uePMgnceDxeNDe3t6QyxBYTUBU26rqEp2qquju7s64jaZp6OrqwvDwMObOnQtVVXHzR88oW5KgXkYmhkIh+B9Ofm+/s/4U3DGZ/qSx1Ov18pFYTZBqyUTXj/4Gd3WvOsCqwWV4+LjUnfvL4aK1N9nfW0mCRD977U01myQAkFQ+Wi+qpZFrPnRdzzoZRtf1ojuJJ1598/v9dkUJlx0QUTrmtkUpT06FEOju7oa664Cyvk66bXuVkxouwVlrSXCigtVxM8OqShQA8cYnmcpKW1tb0dHRgampKYyNjc24ytjU1FTSjuixWKwuOqyHQiHccenMJnHfWpd+CoFTmWATZlJvgpaWlhknVOu/dBTWvDd10zunGYaB/v5+DA0N2UtjKiXdB5E5LbuxuH17ysdqwYNv+aTTIZRFrY1i9Xg8OS3FKrbE1jCMGY0QrcQDEwVElC9z2yLHR/NluxBWbyYmJiBmxZsPO3nhiYgKVzVLDyxCCMyePRtvvPFGUr8Cj8eDjo4OdHR0QAiBrq4uTExMJJ1A+nw+vOvlG0teXVCLV/3Smf7eCCHw8uhyuzSuLXy0Q5Glb+J3+l+/Yn9/3xHX4ownvoV7ll6UclunrRxZg+2b29EzFO/r8K45T+PaHC/i7zKnsm+UxYrNq/GThe+1b99x4M2Yq8WnXbx387FF77+SHj3hP7Bhwwas/NrvcDq+UpdLi1wuV0FNXJ2S6xWxQhIFXq8X4XAY0Wh0RjJCVVXEYjH2JyCiqpLPBZUu8zhsR2GTHGrRfh3nQr4R/55LEKhuSTYzrDhd1zFnzhz4/X6MjY2hpaVlxrpURVHQ2tqK1tZWHHTtN/HsJ36QV7f4fOTaM6EWWd3Jh31nAhVeZRGQobRjAHeNNcH7hAFXAFDP3gEhAP/D3Tj1/tux+orqTBIA8USMZ74H7/7Gr6GdswPXtr+a83Pf9txlJYnhPa/8yP7+oudX4NK5j6PftRsv7Ooryf4rxfr/7mefPw9+v7/oUnYqXq5jD/NdspVtHK2VKGB/AiKqZUu6zit47GMtqdfmw0SNpqr/T/Z6vejv70dTU1PGD4exE5LXLi9YsACtra32bV3Xk27nKxwOV7yEvN5dt/3gGUmC6D3d+P2xn8YvD7oKrX8w8LP3LUXnD/+Ctre9gug93bjj0tOx+orqXG6QyDpJKnQkZKndtvFoPD65wOkw8nbwmviUjsnJSSYJqoRpmgiFQvB6vVm3TXXlX1EU6LoOr9cLr9cLn8+HpqamrGtZraouLjsgIqpuLpcL8+bN43IDahx13KOgKisK8uXzJF+9OuHRL6Tc7uah+IlpIWWxtVYinI+enh6gQudhERnF8c+mrghY/e9L8dprrwEAbrvqdMRiMXzzuc9WJrAS8nq92L0k9zc003tSKo++vrCs+y/WE0tvAAAcdtU34e8FWo/cgSfOuxTbt9duX4Vc1GICRAiRtaIAiDeejcViSX0Ypvc4MAwjpwoB631qamoqIGIiIqqUOXPmQNcrNyGLiOKEEEsBfBuACuAmKeWX02x3PoA7ARwppXwq0z6ruqIgVxEz9x4ChYwJBDI3HXO5XDVbZqXrekUb7KQ6IZ4IxJtFTn+PV46sqUhMpdbU1ATv1tz/PZQ7SVBL/vG9j8C3Fdg52lTXS34stThVxTCMnJow+v1+uFwuaJoGTdOgquqMnzeXEYputxuhUAgul4uVXUREVUzTNLsBOPsSUMOogooCIYQK4HsAzgSwBMB7hBBLUmzXDOAaAH/L5UerzbPbafbszl4GCwBdXV04/4UfFJQssMptUyUEotEohoeHsXJkDTStdoo0hBBYtm4V3vzA9WV7DRMmjn7mAvtruoeO+RR+c8glGPfPzD7XYvO6lSNr0N7ejhe+9JGs2x773Hll66tRa466/zr7v9o5O9DVMVn3iQJVVWuuosDlcqVdJpDuClI0GkU0Gk1ZXWD1SMkkcdkB+xMQUS2b9Ga8eFfz+vv7Id9YzCQBUeUdBWCdlHKDlDIM4A4A56TY7r8AfAVA9is1qJNEgYzm9mO84x/fBgBc8OL/FvQ6fr8/5ahEKSVef/11/PGk/8SiRYuwcmRNTVwNX7F5NYDyraX/n9H5OOaZd6V9/L4jrsWmTZvg9/tx56LzyhKDE4556D9z2i5m1sX/fiVjJQssuZS317JavDqebgKMNbFgukyVVta+Mp38q6pqL1VgfwIiqnVN/iOwpKt+Pu8A8QaN1leT/winwyGqOCEr85XFAIDNCbdH9t63L04hDgcwJKX8Ta4/W+1c/s5AmvlfZcrWZTudQCAAj8cDVVUhpbQ/5JqmiXXr1sHn8+GhYz6F0/7yZTtZcMeiKwp6rXIqNpERkhE8EXLhu1tPxev+ZvhcYXTpU3htoh3RmApTZv6dPLH0Bqxbt66oGKrR2JSBNl8A5//lg/j5vPTbVbqSYNceHzpbix+/WCmPn/FFvPjii06HQdOkWiqQ+LfU7XYnJQzSVUwoijJjBGIqbrebiQIiIiIioEsIkViWdKOU8sZcniiEUAB8A8Dl+bxgXSQKVCP/EuWL1t5UcGl7uiudiqLANE1s3rwZtw9fho6ODrzt6W/iorU3AQB+edBV2L17d0GvWS65VBMc+9x5Wa9+h6MadgdyWwICxBMuuaxPrgUrR9bgviOuRTgcRpsvAJcaw+eG7gUw8/0YNwM447lLKh5jLSUJgPqvJgBqb+yq9fctkaZpSUlQTdOSEgWZejBYSw4yvQ/BYBCKokBV1ZqswCAimq4RxiMSNZTKTSTYKaVMV7azBcBQwu3BvfdZmgEcCODRvRe5ewHcK4Q4O1NDw7pIFLg88Q+aipBZr2Qnamtrw9jYWNJ9brcb0Wi0oLXDpmkiGo1CSolIJII33ngDt8xejuXfeQB4xy6885/fw68OuwY7duzIe9+l1N3dHS9IyeKYZ8/P6/3Mx/T3vZatGlyGs576hn37O4t/ggNcM5MEk2bQkSRBtYvc242YDmgJF5jFSQJCiIImlNQK629NrTBNE16vF1LKtNUAib8vTdPS/nymaULXdQSDwazJBI/Hk3VELhFRLWCSgIjK5EkAC4UQw4gnCC4CYF8Rl1LuAdBl3RZCPArgY9mmHtRFosBaenDWwAv49ciBOT/vvOe/j5uHLoaUMm0pvvV4riKRiP0BGIh/IL7tqtPR19eHzs5OHHX/dbjviGtx1lPfcKRZ38qRNXaSIF01Qbmvet9/1MewdevWsu2/HFaOrEn6fa0cWYPbhy+zR2b+/thP49Q/f2nve5rc1I0NC9N78C2fxPb52+0Kgku/9yCA+IjT3x39CYyM5JDRqlG11sgQiPdpURTFXmIw/eQ98bbL5cqYCFEUJWMywRIMBtHZ2Vlc4EREVWBJ13l1lSzweDwQs/4FIQQbGFJjymEiQSVIKaNCiA8BeADx8YirpJQvCCG+AOApKeW9hey3LhIFln/v+EdeiQIgvu41U5nzis2r8z6hT3UC8Prrr9uvY119tpIT+SYjCrFyZA1um3upfTtdkuD0l96OiVD55t/+6rBrai5JAOybwJCYMLjk1Vv3bTCS+j0NyUhF4qtVp//1K2n//2pubq7bqgJFUWp26Y0QApqmzfg7J4SwfyYhRE7VErkkCgD2JyCi+lBPSQIAGBgYgHxjcTWcJxE1PCnlfQDum3Zfyg7rUsqTctlnXbRdV5T4nyiPyD/v8a6Xb0w+4Ush38Z/6UYkjo6O4qeL3zfj/q6urhRbl44V/6UbbwMAHND5esrtIjJa1iQBAOzYsaMmJkKkYyVbbpm9POu2x//znTjx2feUO6Sa19PTk/L+3bt312WSAEDK6Sm1QtM0BAIBmKaJSCRi/yyGYdjJA8Mw7GqbTHJZTqDrOtxud3FBExFRSQ0MDMDrzb03FVG9qpKpB2VRFxUFYu+75xKpR3eVwvTS8+kURYGu64hEIhknHExNTeHn+/8bLnzph/Z93d3d2L17d0XWK6erJDjnlbfijanmsr9+LScJAGD27NkYHx/H2c/8P/u+vxz6MyjTcm6feuMQRGLl+/dYT97+92/Zyzhuu+p0NDU1QdM0x3t5UGrWxBcpJVwuF8LhMLxeLyKRCNxuNxRFSfobKISAYRj27UgkYv+tyyVR0NraWvofgoiowuqpmqCzsxPt7e1cbkBU5+oiUSD3NtyLyfKu+U03UtEwDAQCgZxHIE5MTGD7xg6o7SF0tk7h6N/9R1nX7QfCLhjuzFf3KpEkcKInQ6lt3boVy9atsm8vbN8xI0nwWBB49PWFlQ6tpg0MDGDXrl2YnJzE5OSk0+GUVa6jAWuBpml2ctTj8SAUCs24+q/r+oy/jaqqwu/351Qp0NbWVsqQiYgqrp6SBKqqoqenh0kCogZQF0sPLKoo748zZ84c6Hpyab6VJMjXQ6edi9ZH95VstbW1QVXLcwV6aipeGpzLKETKLBgM4g8nfgYAcO9Bt+D2OX+Ysc3HX2bzwlzF9ib5TvnTDbjwpR9ixebVdV9mXsvLDgAgFovZ30+vCJg+HjHVNon7CIfD8Hg8MAwDXq93xu/e5/NxLCIRURXp7e0t2+dVopokK/TlgLqoKLBMmuWdvf6WB+MniHcu+QDGx8cBJH9ozmT60oVgMIg/fPUKnPDJm+A6eweO/t1/4Ddv+gjeeOONksa8cmQNutozJwmOefb8kr5mKrVWTZD4+5r+uwsEAlCERI/aNON59TjhYNXgsqT3oL29He/85/fSbv/Amz+OsbGxlEtppJRQVRVNTU1oa2vD8Y98fsY2yzfcUnP/XhpJOByGoihJzQzdbjdCoRC8Xu+M33skEsnYtDCxmez0pACrCYio1tVyNUFrayuampoQCAQwNjYG0zTh9/vR3t7udGhEVAFFXYIXQnxNCPGyEOI5IcQvhRBtJYqrIAoqM2f7ghf/Fz09Pejq6ioqq+pyueA6ewf+fGr8ZOltT38TilL5Ig9Tcj75dNNPVBN/L5mmZNSrxPcjsarm5qGL7e/vOeRq3DJ7ObZs2YKpqSmEQqEZX+FwGIFAADt27MCGDRvwx5P+E9F7uu19PPDmj+O+I66tzA/lkFzW5VczKaV95d/v90PXdYTD4bTjECORCEzTzOnntsbLAvH3qaWlpbTBN4hqOzYTUe3p7OzE0NAQ2tvb0d/fj/06zsWSrvOwe/duTExMQOld63SIRFWhnpsZFntW+iCAA6WUBwNYC+DTxYeUP+u9K2TqQaHe/vdv4exn/h/e88qPctr+x/Mux8qRNejr64vPnRUCJzz6BQDAsb//LG4fvgwASv7BOFvT+D8Hyz/Lfc2ClWV/jXKxxrIllot7PB68Y/CfToVUdncd+EE7MZDqyv6ZT34dP1n4Xtx76L9DSolVg8uwanAZdu3alXI0aDqxWAwbN24EAETu7cbtw5dhy5Yt2LZtW0l+jmoVDodhGAbcbnfNdowOBoN27MFgEC6XC5FIZMayA0s+Yy6DwSDcbjeam5tZ3lq4qjg2ExGwpOs8p0PIW0dHB3p7ewEA5rZFSf0IlnSdB9/Um9ijgKgBFJUokFL+TkppXUJ6HMBg8SHlz4w522ohUwnWypE1aG5uxvz58wHET7IWLFiAFZtX29vcf9THEIlEICVw3vPfL2ls0V91Q8mQhvroy+8q6etN99jJn63ZefErR9bg3f/6PwBI6tru8/lwz+aDYSL5pPjdG06taHzlYp3sJSYJPB6PfWK7anAZAoEA9uzZU/Rr2d3vJXIap1cPotEoAoFA2pPqWqBpWtKJf7YT+nz7MoTDYS47KEK1HJuJqPaWHnR2dqKvrw/yjcVMBhDloo57FJTyDHslgN+WcH85M814Savp0LvY09OTsaz2wpd+aPc3AIA3P3B90uOaFq+EiN0bL8Eu5VU0IYFgNHWlRSXW09fy1eGbhy7G3Qd/CNF7utHZ2YmBgQH09vbi+Ec+D90Vgd+Mn+hFZBRHP3MBXhuvjzV71tIKa5Sl1+u1lw34/X4IIexxeKUy61evlmxftSSxjL9W6LpuJzsswWAw49+tUCiU17Iqq48FlYRjx2Yiqi1WJYF8Y7HToRBRFchaqy+EeAhAb4qHrpdS3rN3m+sBRAGsTrGdtZ/3A3g/EJ9FX0pmJP4BNCRTN8sqtZ8ufh+mpqagqioGBgZw7O8/CyD5Cqx1kpUL62rb6NFhqHt8uOy12wtu5ma9rvX82646PWUslWq6NzExUZHXKQcpJUZHR3H7h87A2NgY3vGPb9uPBSMunPbccgejKx+rQWe6f4OGYZSsT4P1b//nL99gL0NoJIFAAF6v164uUBQFuq4jFotVZS8Mt9udskJI1/WMlUNSSrhcrpx/ppaWFkf6tdSSWjg2E9G+pQfVXFmQuDxClranNlF9c/BqfyVkTRRIKU/L9LgQ4nIAbwdwqsywCFVKeSOAGwHgiCOOKOlbKvdWFFSimeGvDrsGO3bsABA/odq0aRPuPvhDOPe57yatw43e0w3tnB24eejipGUGqbjdbggh0DNrT7yx2zlTBceXqlP/9IkHn3rjkIL3X+umTzDIRgiBpqampCRBPUv13kz/39o0zZynfWTT29sL7ZwdaTviNwKrr4PX60UwGITf77erjJwwfaJBonRVA9a/Ea/XCyklhBAwTdNOHui6Dr/fn3MMXHaQXS0cm+v5wxNRvpZ0nTcjWaDrur2sr6mpCaZpYteuXUUt7XO5XDAMA4Pu07Db9VcIIaCqKpoDR9rbJMZRiz0UiKgyivo0KoRYCuATAE6UUub+KbDUzMp1EW9pabETBZbR0VGsnr8CF6+/OelEK3pPN1acsxrB33VDP2PH9F3Z3vzA9fj5/v+WdF++J7TTJY6022VOoVPx2Y89+vrCgvfrNMMw8J5XfjSjeiPTezW9omLlyBr8bL/3IxAIpDzhdbvdMAwDTU1NeOvfvla64Ktcuvdw+kl8YvO6Qum6jpaWFpz65y8BiJ+A5tPwrp5EIhG4XK6kE2m3213x5ImmadA0zW5UmLhcQNM0CCHSnuwrigLDMGY87vF48q6McLlcNdvksVpUzbGZiJIknpRHO56HNnrg3hsAxgCldy308UPRNf9ZBAIBbN++PeuxwDAMtLe3w+12Q9d1aJpm9xZoj7wFSu/apF4D6yd+AyAEIQT273xniX9CosYi9n7Vq2IvW30XgAfAg3vX6D8upfxA0VHlyaooiKD8HfxP/MN/AQBWz1+R9AE41YfhB76wHG97+pvQAkDot93wnJk+WXDhSz8EAGjn7NumkA/Z060cWQN16yX488HVW/KWi+kn+4sWLcL4+DimpqZwy+zlKa+AulyueNfekZn7e9fLN8647+HjroNhGEn9JOrdYyd/FuvWrct4gq6q6oykgKqqUBQl53+fuq7D5/PB5/PhtL98ecbjVsLg7oM/hNHR0Tx+gtoXi8WSElbTkwblJoSAYRgIBAL2B1KrF4WiKIhEIlmTQon9ChJFo9G8e660trbW/AjJKlAVx2YiSs9OEiSwTug9ew6B0bsWPp8Pu3btgsvlgsfjgaZpCAQC2L17N4LBIBRFwbx58+y/mea2RTM+CU9vSDh//nwEAgEYE4eV5eciovpRVKJASrmgVIEUxUoUyPInCiwXr78ZQHzsYWKX+MSr26qq4ra5l2IZfgu1gAbnQ0NDWL9+fdFXWf970S/t75+uwU7rnZ2dM072j3v4cwCAJ5begKPuvw6/PfKjdsmzoihQVTV+QppHj7xT/nRD6YKuEbt27bL/fblcrqSTVGuefaq14lZJuaqq8Hg8aU9se3t70d7ennPy5dznvgsgfXVDI9A0raITIFJVAgDx5QTFxhGLxewkRK647KB4VXNsJqKCmdsWwQWgv39t0v1erxftkbcATcCE8WR8qVce0wkURWGSgKiU6rgY1rmFsCUk9uYHgg6ULS/fcAvuOvCDGBsbA5B8gnPa9bfitqtOh3tCItSa/xWyEx79An5/7Kexa9cuTE1N5ZUwWDmyBlFTgaaYOEnf97xPra/cWrQH3vxxbNmypeDnCyHi/R1SVARYjrr/OgDxsZOUP+vfLRAvd7fK4BVFyWmsZSwWS1nNYVeAZPjdpdPISQIAFb2arihKXifx+RJCIBqN5vy3S9d1O0FFREQzKwISNQeOhJnnn3COPCSiXNVFosBaHLI1ZmTerkzOe/77AOLj9KwPxNa0gZUja4DlgKvAfVsl2ZY7l3wA4+PjWZ+3anAZzn3xbnS1JjdGnAhV7kP4W//2Ndx3xLU466lvZD35UxQFmqZh+YZb8LP93p9yaQCVnnWSL4TA1FT830q+J2qpTgJT/b5bWlpw7pd+AWDfEpufLHxvWU9Ua4k18aCSyw7K/Xq6rrOagIiIiOqWqOOKgvqYP7X3FxSUhZ6Ol8aKzauTrgZG7+mOTzEooQte/N+cRy/Oap9At3eypK+fr7Oe+gaA7OMi58+fj+UbbgGQun9ArqL3dCN0X/w9D8fyWxvdyKSU9qjCYDCIYDAIj8eTU9IgFovldBV8fHwccu9m1v8XjTztIJFhxJOclUwSALCXTZWSYRhwu91wu915J4FaW1tLHg8RERER5a8+EgV7uVCakW3FSEwW3HbV6QCAwEOlTRYA8RPvbHPGY6aCId/ukr92vtYsWJmxoqCjowPHP/L5kryWds4OeM6KX60Wv+nImqiJmgoCYRdisrGap/3plM8BiK+H93q9MAxjxkl7KBRCMBiE2+3OuC+rYV227QDg9g+ennT7kldvtStvck2A1Rtr0kC6kYTlout6yRM1Xq8XgUAA4XA47yaGPp8PLpezyV4iIiKivMgKfTmgPhIFVXaOt2Lz6qST+N9++EL8+vAPx69231+6pMHlm34Mn8+XdF/iSZcpBb7e9+eSvV6hlq1blfYxj8djN7ArNdfZO5KmSKSiChOGOwK1nuuGpnli6Q0YHR3FqsFl9si7dKMigfiJbDbRaBSRSCSnsXZrrjkTADD5p/j/C1Ki5JU3tcTlcjkyFrLUvRASmyJaCYN8cNkBERERUfWoj0TBXm7hfEWBZe7cuVAUBbdddTrGxsawfft23HbV6fjpB87E74/9dNH7t06s3v2v/8PChQvR3d0Nt9uNn+33/qTtJuW+0uJN0YmiX7cQtw9fNuM+IQRmzZqF+fPnOxBRYhyOvrwjjrr/Opz9zP8DgJyu+vr9/py2k1LC7/dnTRZEo1Hc+fFz0HTcDvx08fvQ9vb1WHPNmQ3ZxDDfNfylIoTIqVllrnRdt/eXaQpGOpqmcdkBERERURWpj2aGe8cjhmX1rEk/6Y9fTLq9anAZVFXFpRtvAzYmb/uHEz+DTZs2ob29HWNjY/a6YUVR0pcjX7Xv223btuHCl36YcrP3v3ouwjEVO/xNhf4oRbvk1VsB7GtwZ5eYb3YqIlo1uCyvsXX5nPzlcnXc7/dj1eAyTE1N4ZvPfqZhexVUcsJBolImKLxeb9K/jVAolPdIxK6urqxLqYiIiIiqTh0XJdfVJ7MIqidRMJ2maWnX3574h/9CNBrF9u3bk5qL5bJmOdt4sy0TrY4mCRK5XK6GXYdebVaOrMnrJDUYDOa8fTka5NWrSi450HUdXq8XHo+nZNUE05MElnz+Daiqivb29pLEQ0RERESlUR8VBXs/a+si4mwcGVy68baMj6/YvDpr6bUQAis2ry5lWBVlVRaQ8/It8zdNM+erxLFYDG63mwmDHFSigaHVL6CUSw0Mw0AsFkuZJFBVNW2/i1Q6OjrybnxIRERE5DjJ8Yg1Q63x2o9sHb+llA25jrvS+B6nFo1GMXv2bPT09MxoojldOBzOqbFho1JVFV6vt6zJFI/HA7fbDb/fX7LKBWuf1mSDVEzTzPl3L4RAZ2dnSWIjIiIiotKpq0RBrcvlijuvvJWXlSSo52SB9bPlc/Lodrsxb948nPaXL+Ptf/8W3v2v/8taLu73+3MamdhovF4vTNPMu+FfrlRVhWEYCIVCJUtE5LPPXJtaAvFqglymahARERFVJY5HrHJ7l04HZe3P4G5ubs74+GWv3V7Qfh2YvlZzHj7uurpPxNw291L7+3zK3mfPno1jf//ZpPve+c/vZX1eOByu+/c0V4ZhQNO0kl7hn85KQhTaqNCqdDAMA16v1/4qZJ/ZljoIIdDV1VVQnERERERUXnV1KScoa//HufClH+L24csQiZS230IjjgHM1yl/ugF/OPEzWL9+PYCZVQVCCHR3d2NiYsI+aaq15oyJ0wVyPVkVQuCER78w4/4fz7s8pyvWVvO8SqzHr0YejwcAyj4G0eVyFV2lUIp9WLL9vtva2rIutyIiIqLKsBpXW59bKDfsUVAjwnWQKAAyL0G4ZfZy/OZNH6lgNI3hp4vfh58sfC9ef/31tNtIKbF9+/akE75aXqKQ60hCt9uNJ5beMOP+XMva/X4/TNOEy+VqqL4FQgi7XD8UCpX1tXRdLzq5WMppCED2niusJiAiIqoeGzdudDoEqjJ1kSh427zFAACzPn4cAOmvVJumiTfeeKPC0dS/d//r//CeV36U99XUWl1f7XK5cr7Cb5omjrr/uqT7Ar/rzvs1I5EI/H5/wyxF0HW97FUEFkXJ/2+fYRhJt/MZl5mLTImClpYWXrFoAG9dsMDpEIiIKIsx9+N4efRu+Hw+HpsLwR4F1e3Qnl4AgC4aZxzbnUs+4HQIdSnfE65cr8pXg9uHL7O/zyfBEYlEcP9RH0P0nnhyIGoqcBVx/luryZV8WCMJKyWfpoVutxsulwuBQACKosDr9Za8mgDIvLSluzv/RBPVnoP3HpuJiKg6bQr+Dlu3boVpmjw20wx1kSh4134HAQCUGh+PCACPHH89bpm9POM2QoiCriBSdoWso7/30H8vQySll1ianu/V46RKi18VN86u3nsVlHKdfy7cbnfOCStrJKP1b8GavlCOpRGRSCTlv7OmpqYZ1QxUn95z8EFOh0BERGn8a/c9mJycBBBvpq7rusMR1SYhK/PlhLo422z16EDzZ6GL0jYAdMLJj/03Lt/0YwDx5QfTS4BWjqzBis2rcd7z33ciPEqhkieFxUhczhKLxfJ6bnt7O7Rzdti3b7vq9ILjKHWjzmpT6YqJXF/P4/FU9N9qNBpNmdDkFYvG0aYbQPNns29IREQV9XrskaTPgjw2Uyp1kSgAAHjOwuzWDzkdRcldvP5m+wRv5ciamm6eVwvynWLQ0tKCi9beVKZoSuf24cuS/u3kc7Lu8XhK1oSwEbrcl3qtfza5VhNUupLD4/HMSEhZYxepgXiWQjRd7XQURESUYPfu3fb31ihkKkCl+hM4VFFQN4uFFa0dumshgO1Oh1JSvzjgSuzZs8dOEtTaOL5aNG/ePIyMjGRc9+1yudDR0YG3Pf3NCkZWuOmJAV3Xc7663N7ejjc/cH1J4tA0re4rCipJCJHz+5lvFUmx0lUTVDqRQs5StE6Y6jynwyAior02BX8HYNK+zWoCSqd+KgoASOXNePectzgdRsncPHQx9uzZA6C2x/DVmpP++EUsWLAAXV1d0DQNuq6jra0Nvb29GB4exsqRNbjk1VtrJkkAzKyUyPWkUVVVtLe3J91XzLIDniSWlpQSqqrmtK6wkhUFhmHMaObo8XjQ3NxcsRioimgHAt7LnY6CiIgAuy8BEL9w1NTU5GA0dYAVBbWh19uFA1tn46f4q9OhlMSKzauTEgQ+n8/BaBrL0b/7DwDAE0tvmDEasBYl/jvyer0ZO9In6unpwVse/EzJ4qj0Ve1GEI1GEY1G4fV6EQwG0yYEXC5XWao5dF1HJBKBx+Ox+xKkmvjAaoLGpbjmwIywsSERUbXhsZkyqauKAgCY3zTL6RBK5rGTPwuv14uuri4MDw9j7ty5TofUcOotSaAoCvx+f06j+1wuF8588utJ9/3+2E8XFUs5uutXm1yTMJm43e68Zxn7/X4oipK2ukBV1aLjmk4IgWg0ilgsBr/fj0gkkvLnd7vdaG1tLfnrUw3RFjgdARERJXC73WhpaXE6DKpidVVRAAALWnrxuYMuxOf++XOnQyna8Y983ukQqM6oqppzCfolr946475T//wlAIUthXG73Vi+4Rb7uWzOmd7yDbfY398655KcKzEyVRdEIhF4vV6EQqGiKzushEQ4HE5qpiilRDQanVG90NvbyysWDU5x7w+z+cvAxKecDoWIiAD09fXx2FwkAedGF1ZC3VUUAMCx3YuxtO8Qp8MgcsxfT/8vADNP6Et1VTnf6QVWkgCIJwjqOUkQCASK6h48vZ/E8PBw3r83v98PIURSdUEsFrOv/hfK4/HAMAyYpgm/359y4kIsFrN7JwDx2cy8YkEAAP1kwPN2p6MgImp4zc3N7BtEWdVloqDV7cVRnQudDoPIEY+f8UWMjIyU9UQ8VbVBKkII9PT0JF0hD8dU3Dx0cZkic46iKPaIoVxHFiZyuVwpp5rouo65c+emnCKQSSwWQzAYhGEYeT83FcMwEAqFclq2Eo1GoaoqFEVBX19f0a9N9UFR2wF3/TQcJiKqNa9O/RZCCB6bS6mOmxnWZaIAAM4aOBQn9xzgdBhEFXf07/4DExMTKR/LNPIxX9nK1YQQWLF5Nd7+928BAMYmDWzf3oJHjrm2JOv4q42UEoFAAH6/v6D3OV3y5aj7r8OJf/ivgqcWBAIBCCHg8/kK/v27XK68+0uEw2F0d3fD7XYX9JpUn4T3PMBd+OQUIiIq3LDvTB6bKWd1myhQhIIV809yOgyiqmKaZt7LBtJZsXl1xseHhoaSbs9d9hIWXv502iRGrZNS5jSmMJVUlQSJiq0OsZIYhTAMA7FYLO9EhcvlQmdnZ0GvSfVLCBXw/ZvTYRARNayuri6nQ6grQsqKfDmh7poZJtqvdQDXLD4TzS4DX3z+LqfDISq7XE4oSzkmTwgxozrAqiTAyL77Hjn+ekyNTGHnzp11Pfmg0EqJ6D3dGD0mhJ7u8aT7Hzv5s3jllVfy3p+VsJBSwjTNgk70NU2DpmkFJxj6+vpKsuSB6o/iORhm0ycg1A7IPWxuSERUEb6rIPRTIHhsphzV/b+Us/oPx6apnU6HQVQ1cj2Z/eVBV2XdZsXm1XZzQiCehBgeHk7a5uahi/Hqq69i+/btME2zrk8eg8EgPB5PQV2EO/4ycxzi6Oho3vsxDAPBYBDBYBChUAiRSCTvJIHb7bZ7HBSCDQwpK/1cyOgGp6MgImoc5gSE6yCno6gvlepPwB4F5dHu8WH/lgF8aNFbnQ6FGtgTS28o6/5XDS7LuTzdOpnNZvfu3XnFsHJkDS559Vac9McvAgDuOvCDWDW4rC77EWQSCoVgGEbO21tLQdSzd8x4rLOzM6fflcXj8cA0TTtRoWkaVo6syWtqgqqq9uSCQggh0NvbW9BzqXEoWheg7A80fdLpUIiI6p/7dMB7mdNRUI2p66UHlpN7D8Bvtvzd6TCogR11/3VOh2CTUiIcDue0BGHV4LIZ6+etpEemn+nOJR/A2NhYyscCgQAMwyi4pL0WpBpBaE1DUBQFiqLA7/cD2LdWMFURwnEPfw5AvCojlxN3TdPw7n/934z786ko8Hg8dmyF6Orqyiu5QY1LeJdC+n/pdBhERPXPOAuKayj7dpQ3UcfXwxoiUaAIBfN8s5wOg6gsVs9fkfe6fyklNE3LqVfBqsFlUBQFZz16H3rmjeaU9BgfH8/4eDAYLGmvhGoTCoWg67rdwyExMWDxer0A4mX+kTPH0v4xXrNgZdolAM3NzbjwpR/ijkVXIBKJpEwSAPn1Tih0ugIQr47o7u4u+PnUWIRQIbV5TodBRFTfjBUQ+mlOR0E1qO6XHlgOaB/CFfNPcToMopK7eP3NBT0vn3X0pmnikTPPL9m+pZQlm75QrYLBIAKBAILBYMor9H6/H36/H+Pj4zDcqRMm9xxyNSKRCDo7O9HW1gZNi6cTVFXF4OAgLnzphwCAi9belPY9v3PJB3KO2ev1FtyXAGADQ8qf4jkc8F7pdBhERPWp6WOA5wQIwUq/sqnjHgUNUVFgefecYzAZCeKOTX9xOhSimuNyufDE0htyqihYsXk17lh0BS5ae1PK3glCCAghoGkaotFoOcKtGeFwOO1j5zz7nfg3r6V4cNp9yzfcMmOTnyx8b9bqjkTFLAdpbm5Gc3Nzwc+nBua7FMAk4L/d6UiIiOqLaIaiH+t0FFSjGurST6vbi/3bBpwOg6gmWVezs7F6GFy09iYA8QSDVT3gcrlgGAaEEJiamkIsFst5v/Uq3XKBUsj3xL/QagCrgWEh0x6IFLUT0A5wOgwiovrjZpKg3ISszJcTGipRAABn9B6Ms2Yd4nQYRCU1veFgOWialrWaINV0B8Mw7F4EkUgEgUDAXgcvpYSqqg17glnuEYJutxtutztphKVVyZFKPtMRErGBIRVNPxtwneN0FERE9aPpeiiu2U5HQTWs4S7lqYqKdw8fi7CI4aFtzzsdDlFJ5Doa0SKEyOtqs8fjyemkNlUi4YIX/zdjfKFQyB7rZyUNwuGw3WzRWqZQj0sUyt2nYc6cOTj+kc/btxMTSj+ed/mMZQ+FNDJkA0MqBUXRYDYtBwImEPyV0+EQEdU218kQvoucjqIx1PHUg4arKACA/dsGcXg7Oy1T/Ui8YpwLXddz7oRvGAbmzZtnj+orB9M0EYlE7AaApmkiFArBNE3EYrG6bXyY77SKfCUmCaZbvuGWpCoAXdcLSsawgSGViuI5BHAd7nQYREQ1TzStZANDKlrDVRRYTp11IPyxEL679gGnQyEqiWxVBaqqor+/HyMjI3ntVwiRV0m6FYd1pXlsbCxl1//psSWOSpyexIhEItB1vaiO/NUoFArl3CCyHBInZqxZsDLv57OBIZWc562ADACTX3U6EiKi2uS7EsLzZqejoDrQsJeB2vUmvKVrkdNhEJXEfUdcm7WqYGBgAKf/9StYsXl1XleOU131TtWLYLpIJIKtW7faSQIhBAzDgKqqcLvd9na5jOSLRqMIBoPweDzwer110wAxEokUVO5fDsvWrcpre03T0N/f37D9Jag8FK2LzbeIiAokmq8DjPwT/1SgCjUyZDNDByxs6cOHF53pdBhERTvrqW8ASF9V0NbWhtP+8mX79iWv3przvmOxWNH9AXRdh6ZpCAQCiMViCIfDEEJA1/W8eiWEQiE78aAoClRVLUvSwO12w+v1JiU0ymXLli2455Cr8evDP4zfHvnRsr9eOj+ed3le2w8ODtbtkhByluLeH/B9wukwiIhqi/EBSNehULRWpyOhOtHQiQIAuHDuW3Ba70FOh0ENLJer87m4ffiylPdrmobznv/+jPvzuRKc61r6uw/+kP29dbKtqiqCwWDS0gIgvrwgGAzCMIyc47BEo1GYpglN00ra5NAwDHg8HoTDYfj9/oqsvd+zZw927dqF7du34/XXX8cts5eX/TVTmd7YMJPu7m40NTWVMRpqdKLpUsBzhtNhEBHVDrUNivtQp6NoPLJCXw5o+ESBS9Fw1aK3Oh0GNbBSrU/v7u6ecWIrhMDAwEDK7VdsXp3zvnNNFJz73HcBxJcTWCfbsVgs43MKLb03DGNGXB6PBy6XC16vF7quZ92HtZTBMAwYhoFAIJC0TycmLZimmTbpk85tcy8tUzQzeb1e9PT0VOz1qDEJ4YZoZlUBEVGuhC+/zw5E2dTHQt8iDXg78NVDL8Ynnsn9xIkoH9Mb1iUuERgeHsbJj/130a+x9In/wV9O+wJ27tyJsbExtLe3o6OjI2N5uKIoOZ2oTz8hz5TcaG5uxsTERE4xF9OgUEqZFL/X60UgEICUEpFIxO7orygK3G73jNexxi9mSoJEo1F4vd6szRhLLRKJpFxGIoRIOa2ikKqMRLmO11RVFUNDQ+xLQBUhtNmQLd8Dxq9yOhQiourW9UcIkXvjaSoNAef6B1QCEwV7ndR7AK5ZfCaEEPjWy/c5HQ7VkUxJgpUja4D8hhBkdMxD/7nvxsbU2/z68A/j7X//FgDg8k0/zukkMZ8Twwtf+mHOJ565jmhMJRgMwuVyQQgBl8s142Q+FArZVQeJ22qaZo9fzOX1/X4/PB5P2UcZ5iJdvMU0RLxt7qU5V06wLwFVmuI9Hab5SQjhgpz4otPhEBFVF/0CwDgLitbrdCRUhxp+6UGi84feDLOIExeiVDImCSrs3kP/Hdu3b0+6z+v1Zn1ePuMRAeRU9g9gRt+CfFljE9Otrw8EAvZJdCQSsZdDBIPBvJIU1TKZIN3vYWpqquB95pok6Ozs5ChEcoaxDBKZlzARETUkdQ4Uz3FOR9HYpKzMlwNYUZBA19w4qWd/RGMxfH/d75wOh+rI9KoCALhj0RVQVdWeANDc3Ix3/OPbZY1j586dM6oDLlp7E4DM5ef5Jgra29uxZ8+epBPsVEsMPB5PXlMPpjMMo6iT5Fy4XC7HEgWKokBRlLRVE4lWDS7LO/mUa+WHYRiYNWtWXvsmKhVFNWC6TwKaosDk15wOh4ioOhiXAd4VTkdBdYyJgmkGfV0Y8HU4HQbVmVRXr6ef9LW2lm+cTeIJYbqT/pUja5K2c7vdaGtrg9vtzrvD/ZlPfj1pX6mqFopd+y+EKCrJkI9sDRlLTVVV6LqOqamppIqIUso1SaAoCoaGhioyAYIoHcU1DDPCZBUREQBAfzfQdDkUtfxjnCkz9ihoMKf3HYx149tw86uPOh0K1Yk3P3B91m1yWQJQCrmWmre0tNi9DPIx/QTU4/HANE2oqgpN06AoCqSURTcIlFIW1QwxFy6XC5FIBC6XC83NzRgdHS3L67jdbgghEIvFoKoqQqEQYrEYvF4vTNPM+DPm2pAyUa5JAgAYGBiA280PIuQ8xXs2zMhaIHCj06EQETmn6WOAthCKmnqqFVGpMFGQxooFJ6HJpeM7a+93OhSqA3865XNYu3Zt2sc9Hk9JJh/k6vbhy3DJq7fat+9c8gG0trZi8+bN9n1nP/P/Ct6/qqrweDyIRqNJTQCtk99SVAJ4vd6yjy+0pidcvP5mAPmdYOdqemWF9TMFg0F7YkM61khHq9nizUMXo7+/H2/9277y7Aff8kls2bKloOUTHR0dZa10IcqXaL4SUmkFprgEgYgalDIIRT/Z6SgIAOTerzrFWtI0dNWNY7sX4+yBNzkdCtWB4x7+XMYTLutEtFLmzJljf3/z0MUYHx/Hrl277DXuuXa2/8UBV+IXB1yZdJ+maYjFYvD7/SmbDPr9/pybHU6n6zq8Xi88Hk/a/ZeSEKKsSQK3252yskJRFHi9XiiKkrGawEq4WEsVDMPAzp07ceucS3DXgR/ELw+6Cps3by4oSaDrOnp72UWZqotQfIB+AqBf6HQoRESV530vhHGa01FQg2BFQQbzmmfhyM55CMYi+N2255wOh2pcuivDXV1dJR2RmI3X68UJj34BALB6/gr7ir/V1HB6Q7xUjRiB+Inznj177O8tuVzlDwaDeY0cNAwDABAOhyvaL2DF5tUAgFtmLy9ZQ0NN0+B2uxGJRFK+V0IImKaZdWmG2+22EyWpth0bGys4RvYloGqmuBbDdB8FyBAQutfpcIiIKsN1DOC9CEJwOWA1EdUxGKssmCjI4oy+QzEWDjBRQEWLxWIp15OXu3x+uqamJjyx9AYA8bF6W7ZsyXhlfnqS4La5l5Yk5kyTFAzDgBACUkpEIpGKNS1MlNgzYtasWTMaNObLqqIIBoMZ3z/DMBCNRmGaJtxuN0zThGmaM35H+U6iyEd/fz88Hk/Z9k9ULGGcDWnuYaKAiBqH90Io2pzs2xGVCBMFWQgh8LaBwzEWmcKP1j/idDhUwxRFweWbfozbhy9L6mA/NjaGVYPL0NbWhvOe/35ZXjtxosHo6Ci6urqgKEpBfRFKkSRINerP5XLB5XIhGAw6khiYzqqwAOJTHAqlKErOYyB1XU/Zr8BahqAoCkKhEDRNmzHmslTa2trQ1tZWln0TlYoQAtI4FzB3A/7vOR0OEVF5ea+GYrzN6SgoFfYoaGxNLh0nzlridBhUY+455Oqk21ZzwHRj7qwy/nIxDAMulwtutxtH/+4/7EqBJ5beYFcYZLJqcFnJ1ulHIpGkK/ZerxeRSAR+v79kJf7FGBgoTSdhXddzHuOoaVrayg6/32+/P7FYDKFQqCyVKB6PB/39/SXfL1E5KGoL4DnF6TCIiMrLeynQ9F6no6AGxIqCHO3XMoBvHX4pHnnjRdyz5Smnw6Eq9dfT/wtbt27F5OQkdu3ahVWDy9DR0YFzn/suAOBXh12DHTt2pHyulOVNSb7nlR9h1eAyRCIR/HTx+/Duf/0fgOSlBTcPXQxFUeDz+dDW1obT/vJlAOVp5Of3++2+DcWOSiyl2bNn2z93oVwuFzRNyylBYFUcKIqCqamptPuKRqOQUsLtdkNRlJK/Z5qmYc6cOexLQDVF8RwEs+0HQPBhIPhzp8MhIiotYxngXQlFqcwIbaJETBTk4Zie/bAnEmCigNJ65ZVXEI1Gk062RkdH8Zs3fQRve/qbeMc/vp20/fQT8FvnXILLXru97HFOTU3Zr201L7x56GJIKRGLxTA+Po7x8XH8bL/3Y3JysmxxWKX01cLn8xWcJFAUBUIIe/lA4vhJi/UeA/t6EST2YLDGHVoND6WUdnNDRVHsiRKZJiEUGvvcuXMzjmIkqlaKfirM2DgTBURUf7zLoWis9Ktmoo6XHpQkUSCE+CiA/wHQLaXcWYp9VqszBw7DWGgK31x7n9OhUJX4y2lfwNatWzE+Pm6Xg09fa56qU//Dx12HjRs3Jt0Xi8XwiwOuxPkv/KAssaqqOiMWK2GQqqJhcnLSPnkth2AwCF3XS37iWyiryiIV630SQqCpqQnNzc1Y+sT/5LX/FZtX4+ahi6Hresr3NBAI2O9HNBqFYRhlr7YQQmDOnDkFj6yk6tVIx2bF9854ssCff98VIqKq1H4XFNcCp6OgBlZ0jakQYgjAGQA2FR9ObXj33GNw7f5vdzoMqhLbtm3D+Ph40n2RSASGYcDj8cDtdtv9CQDY/QBO+dMNKZvG7dmzpyyl/gAKqlYoV9M8izUqsRrdsegK/OqwawDEKy9WjqzBis2rceFLP8w7SWDp6OjImHhJTJqU+70HgKGhIfh8vrK/DlVWIx6b0XQJ0PQfTkdBRFS81v+F4jnQ6SgoGwlAysp8OaAUi1G/CeATqOuej8kURcG7Zh+NjzNZ0PCeWHpDypNcq5w8FAph+YZbkh5L7AlQrikH6RSSgCh37wQAdid/J1jLBawlGJYfz7sc4XAY7e3tJX296UmlTPx+v51sKoeBgQG0tLSUZd/kuIY8NgvfxUDTZ5wOhYiocC3fgGKwUSs5r6hP5kKIcwBskVI+W4krX9VEEQrOGToKQTOK7/zrfqfDIYdYJ/2FVgA8cvz1ePXVV1M+dseiK5JG9OXr14d/GG//+7eKrk4IBALwer1lLYEv9/4zsUYyTn+f7ATPxtK+XrqpF+lYPRxK/R7NmjWr5EkQqg6NfGwWQgV874JEEJj8mtPhEBHlTLT8NyR0KF5eiKwl9dyjIGtFgRDiISHE8ym+zgFwHYD/zOWFhBDvF0I8JYR4Kl3X91rjVjS8c/AoLJ9zvNOhkIMeO/mzeW1/y+zl9veZ/l/w+/340ymfyzueW2Yvx6rBZdi+fTt+srA043SsK9vlUGgHf1VVoSgKdF2H1+uFy+XKuL2maXbVgNvtxqxZs7ByZE3SmMZqFgqFsv6Muers7ERXV1dJ9kXO4LE5PSE8gHERYKxwOhQiopyIli9DyigU7zucDoXIlrWiQEp5Wqr7hRAHARgGYF2xGATwdyHEUVLKbSn2cyOAGwHgiCOOqJvcS5NLx8XDx2GTfxf+uONFp8MhB+zevTvtY6qqzrjv8k0/tq9eZ5soMDo6mnc8pmnm/ZxcpPpZSsHj8eTVLNHj8SAWi9mNI601/R6PJ2WzRgBJIyqHh4dx8mP7Gp7t2bNnxvbNzc15/Qy5Kqa6IxaLIRaLQVEUe0RiLBabMTXCGqWYTmtrK3p7eyvS/4DKh8fmzBS1GabvvUDsNSD8sNPhEBFlJKObIZqvdjoMKkTdHDlnKnjpgZTynwB6rNtCiI0Ajqj3zsqpdOrN+Mj+ZyEYC+OJ0XVOh0MV9NAxn8KmTel7hQ0MDACvFb7/s5/5f/j14R+G1+vFKX+6IeO25WqAaAmHwxBClLxnQT4nrEIIKIqCcDg84zHrhHn6lIaWlhY7SQAgKUkAxHswaJoG0zTtJMusWbOAl/L6MbIq1e/HGpVoVWEoigKPx2OPUbSaQ0aj0RlJE5/Ph4GBASYJ6hiPzfsoWg9ky6cgx8JA9E9Oh0NElJp+AUTzByFEKVrHEZUO/0WWyIC3A/++35k4q+9Qp0OhCnhi6Q147OTPYmRkJO02nZ2dRTeKs5YQbNy4EbcPX5b380t5QhiNRh2dTmCV3QcCAQgh0i4ZCAQCUBTFflxR0v+Z++2RH8XKkTW4dONtaGpqAgC0t7fjhEe/ULK4fzzv8pIlCbxeL4QQSUs1TNNEIBCA3++3qytSLVPQdR2zZ8/O+H4Q1RuhzQVargU873Q6FCKimfS3Q7RcDyFKs7SQKksg3qOgEl9OKNknRinl3Ea8YpFoUUsfzhk8Eu9fkLIilOqMaZpobW1NKsn3er3o6+vD4sWL0dfXlzThoFiFrE8v5dV/r9drl70bhgHDMOxu/Jqm5ZVE8Hq98Hg8MAzDrhLIRtM0++cxTRN+v9+OJZNM78GZT37d/v6CF/8Xw8PD6Ovry/GnyG7NgpUpqx/ypaoqPB4P/H5/zr/TxOUHbrcbc+fOLdvyEapePDYDivtAwHgn0PRhp0MhItpHvxCi5T8gFI4opurkzDyyOnZY5zC8mgc3rnvI6VCojApJANw+fFneHe8TZZqAMP2KtdvthqZpJeuSn67jvsfjga7rME0ToVAo6Sp/IBBIOqm1TnZjsVjSvrxeb8a+ClbTwlR9DKyTcE3TEIvFIKWE1+u1r7ADwPkv/CDnn3P6soRi3LHoipK8/y6XK2UvglyeF41GoWka5s6d69j4SaJqoOhHwww1AfiW06EQEUG03ADpPhFC6XA6FCqGlPGvOsVPjmWwuLUfXz9sOT76jx87HQpVkUtevdX+Pt9SdKtbfz5KlSTQdT3tvqafvCZup+s6FEVBKBSy18znEpMQwq5OME0TUsqsCZZoNGonM6SUdoKikPetWFaCoFTvv6qqBSWYotEoFEXBnDlz7MoPokameA6E2fJdYPxDTodCRA1MtHwO0nUUFK3b6VCIMmKioEyOn7UEVy44HT9Y96DToVAVWjmyBjcPXVz00oDfvOkj2LFjB1wuFxRFgZQS4XC4ZI0H01USZJPYWA9ITiAkJgKsGA3DsJv0BQIB+3n5SHXF/ZbZy3H5pvIn7H5xwJWYmJiwl0SUitfrLbgKJRqNYs6cOVmXZhA1EsV7BszoNYD/206HQkR5WD/xG/s4rygK2tra0Kuc5GxQBZLqYiiu2U6HQSXiVP+ASmBXqzK6fP5JuGT4eKfDoCq0anAZVmxenfP2t865ZMZ9t829FG+88YZd9m+dYKuqCl3Xi76KnKmSIBu32512bb7H40EwGEQwGEQgELC/NE3La0zidLFYDF6v106OeDwemKaJB9788YL3mcmqwWV2ZciePXtKPpbSev8LaT4ohMDQ0JDdoJGI9hHNHwSMK5wOg4jykHgxwDRNjI6OYt34rxHrfMHBqPZRetdC6V074/6t0Yfx8ujd++5o+wEUz5sqFxhREZgoKCMhBK5a+FZ85sDznQ6FqkTiyWWuyw88Hg8ue+32pPvuWJT+Q24kEkEwGCy6u32hExMyPc8wjJTVArquY2pqqqDXS+T3++11+aFQCJqmobm5uej9Wm4euhhA8u+uHGMp3W533j0JLNZyg2InbhDVKyEE0PwxoOVLTodCREUIh8PYsGGD02HYzG2LZtw3NjYG0zTx8ujd8Df9HYp+qgORUVnJCn05gEsPykxRFLxj8E3oN9oQNKP4yNO3Zn8S1aXpJ5SFrJ+39mFd6S90aUAurKv8id3zE01f2qAoil0tMP0kV9M0CCHSVgyUcmSfFa+mabh0423AxuL3+dPF78PU1BSklGVJDCSykilSyrwTBqqqYu7cuVxuQJSFoiiA93yYSh8wdrnT4RBRgSKRCF7ceRdcLhc6OzvRET3GkTisJMEu9c/ojB1r3281ceZSQKpFTBRUyJs65+PlPVtw7uCRuHvkSafDoQq668APYmxsLCkx8MuDrgJGit+33+9PmSxQVbXgioBE0WgUhmEgGo0mrZX3eDwIh8P2uMRoNGqfoE/vi6DretaeA6Uc45gYeyncOueSklQ75MLlciUlU/IZZ+hyuTB37ty8xlQSNTpFPwZm+y+B4Bog8HOnwyGiFF7ceVfWbSKRCLZt2wb0/qWoZMF2/BHRaBSqqkLTNLS3t0PZuSSn574eewR92JckEC1fRpeyHr62U9hUmGoSEwUVtF/rAJZGD8WIfxRPja53OhyqkPOe//6M+975z+/lvZ904xX9fj8Mw7ATA4FAAG63u6CGgKlYJ65NTU0Ih8OIRCL2NAIpZdLrRCIRuFwuO05d1xGLxbK+Ri7bOOGW2csrGtv0yopAIADDMLL2btB1nSMQiQqkeA6AKd8ORDYB0b85HQ4RTaMoSk59gLxeb8FJgtcCD+y9KLAz6f5du3ZhcPDv8E4envJ5b8g/YJY4EZH2f2L3K6+gr2vfYzL8NFo7PgJFY5KgnrGZIZXM4Z3D+Mj+Z+HozgVOh0I1ZNXgsozd7wOBgD2ST1XVklUUJIpEInaDwnSxRKNRmKYJTdPgcrkQDAazdu1XFCVt48NirZ6/ouDn3jb30pI3KMzEMIyUywwCgQC8Xm/a5/l8PgwPDzNJQFQERX8LROunAddxTodCRDlSVRUdHR1Y0nUelnSdh7nepTO2SdVgcLoXd96VtnIwGo1i48aNaZ9nJfJduw+y7wMA6OdDtHwaitaV8rlEtYCfLB2wsLkPnzrgXPz41cdw52ZevaC4W+dcMqNpYSHr4aPRKCYnJwHEy9FdLpd99d8an5hvqX/i8oFMz01cX58rj8dT1LSDRG63G5qmQUoJIURRyZJSLV3IRbZeBOkSKS0tLRgcHCxpjweiRiVcSyBbPw9M3QwEyj9WlYhyk+pYrigKFrefk/W5qRoMAsnjFnORuPxhSdd59m2/3w9My+Xv1h5ER2sfhGAlQd2TAMz6LSlgosAh/d4OXDH/VHS4m3Dj+t87HQ5Vgcteu73kjfIikUjSFX1VVQvqB5DPCXc++7f6G5SClaRIPKkupGEkUJ5JBunksrTA6hWRuF1HRwf6+vpKXjlC1MgUbQhm0wcApR2Y+o7T4RARgMXt58w4US/ETuVP2L59+95bhU0WAmb2TEi83dnZiY7OXh6bqS7wMpSDOvQmLBs+DlctOsPpUKhBFNroLtcS/FyTBB6PBz6fD0KIrEsTcuH1ehEIBErSFLGY5Qr5MAwDuq7nXE2R+Dvo6elhkoCoTBS1B8K3AvBd63QoRLRXocmBRBMTEyWIJL1Zs2aht5dJgobD8YhULl7Ng/fMORZRU+KH6x50Ohwqowff8kls3rw56b6VI2twy+zluHxTZcpc87l6L4SAYRgwTTPn0vZc1slbV8atkr9cpiJk21+6EZH3HXEtznrqG3ntL59SxEIVMtbS+h309/ejo6OjHGER0V5CaYL0rQAQYWUBUZUoNllQqmWOqQwMDKC9vb1s+ydyAhMFVcCturBi3omIxSK46dVHnQ6HyuT0v35lRkn7qsFlME2zYqXuiVfcNU2bkTiwehoA8XXxuZ7MejweqKqKyclJNDU1IRaLpexV4PP5ZjQMCgaD0DTNbsBoJQ1SxZdIUZSsSYZ8lzXcMnt52RsY6rqed5IAiE+GmD17NlpaWsoQFRFNpygemL4PxtefBr7rdDhEVIWEEBgaGuKxuYHV89QDJgqqhKIoeN+i0zG/pReffvYOp8OhMkkcHeiExBPyQCAARVHgdrsRi8WgaRpM00w6idV1HaZppm2mp6oqFEVBKBSyT9ytRorW8xVFgZQSsVgMU1NTKdfkR6NRRKNRaJpmVzHEYjGoqjpjPKHVsNCa9JDJ2c/8v6zvyT2HXI3R0VFIKcuaJFAUBS6Xq6AJD16vF7NmzYLP5ytDZESUjqKokC1XQ7oWAuPXOB0OkU3pXZu2UV89y/fnfnHnXVjSdR5enfotgNJWFKiqijlz5mScTERUy5goqCJCCJzadzC+CInnd2/GHZv+4nRIVGKLFi3C1NQURkdHMT4+XrHXtQ5i00+sTdNEMBic0SvA4/HYj2malvIgaJpmUrPEVNMLUl3tDwQCaRv4WQkDi8/nQywWg6IoiMViCIfD9lcufrLwvRBCwOVy4fwXfpBym127duW0r2JpmlbQsgZN09Df3w9d18sQFRFlI4SA8J4JU0SAPR9zOhyihpctWTC92SBQ+mUHmqZh7ty5PDYTUIL+WNWKiYIqdEbfIWhS4394mCyoL29+4PoZ91Vi2UE0Gs14ci2EsK/UR6NRxGIx+4R9+sk7kHpZQLbmPdb+TdPMudGPlLLg/gXTGwUmLitYvHgxjv39Zyvy3lt9KMLhcE4TDhK53W7MnTsXbjdHLBE5TTHOhilagPCfAP9tTodDDSba8TyCwSCCwSC6zOP2nSj3vIxwOAz32MHOBlghmRIEGybvS/mZIVXioBgejwdz5szhsZnqHhMFVeqYnsXo1dsgIfHTTX91Ohwqo5Uja8p6wppL4zzTNBEKhaCqak5XvVONNUx8DWsZgmma9rKDxEqAXDPwfr8fhmHYz89Vqt4FpmnuG5c4kvOuimI1ILQSI9OXUWTS2tqK/v5+qKpaltiIKH+KfhJMpReQMSCw2ulwqIG88sordt+f7bgLiqJAVVVEdr4IAOjt/Qs6osc4GaLjimmMnCsem2m6eu5RwPGIVWxeyyxcuegMXLngdLy19xCnw6EyshoIlloujfO8Xq89qi/btrquo7u7GxetvQm6rsPr9UIIkTQVwev1wu12w+/3IxgMIhQKzUgqhEIheL3enA60gUAgp2kKFsMwIIRIeo6iKBgcHMx5H8Xyer3o7++3p1lc9trtaGlpySnZIYRAf38/BgcH+UGEqAop7v2A5o8D3g8D+rlOh0MN4KVdv5zRHNha/mdp9CTBbld5L6oJITAwMMBjMzUUVhRUOa/mwYoFJ+Phbc+jS2/B6o2POR0SlcHQ0BA2bNhQln2nuyLvcrnsRoW5TAdobm7GhS/9EADwu6M/gZGREawcWYNfHXYNxsfH7UqEQCAw4wPNdFJK+P3+nMcE5jO9IBAIQAgBj8djP6+9vR1nPP5Ve5ubhy7OGmOhPB4PLlp704z7+/v7s/al8Hg8GBoa4ppHoiqnKF6g5YMwA78FlC7AP/P/eaJSSJUkoJl27NhRtn3z2Expyb1fVUAIsRTAtwGoAG6SUn552uPXArgCQBTADgArpZSvZdonKwpqxCm9B+KdQ0c6HQaVyUl//CJmzZpV8v0Gg0EEAgGYppmUATcMA5FIJKkXQSZCCDtJAABnPP5VGIYBAHjHP76Nnp4e+zFN0+DxeHKKb/qHH6/XC6/XO+NgnGv2XtM06LqetF8hBDo7OwEAt865BKsGl5X1Q1dzc3PK+4956D8zvi9tbW2YP38+P4gQ1RDFOBMwLnQ6DKpT68Z/ndPxKp+qu3qV7zjkXLW3t/PYTFVPCKEC+B6AMwEsAfAeIcSSaZv9A8ARUsqDAdwJ4KvIgomCGjLb14U/nfEFvH/+qVg57ySnw6ESe9vT3yzb+LtoNApVVeHxeKAoSt7df1N9UHnPKz+yvz/9r1/BypE18fWSkYi9tCATr9eLSCRiJwesCgdryYI1TtDtdts9D6azkhK6rtuVE6FQCG1tbQgGg1g5sgadnZ0IBAJYNbgsrx4Bhco0kvHi9TfbP5OVaLGWRQwODiYt4SCi2qC4hiFm/RPwXgX4rnY6HKojufbmWdR2dpkjqV4TxpMlb1YI7Ds2DwwM8NhMaQkAQsqKfGVxFIB1UsoNUsowgDsAnJO4gZTyESmlVcb7OICsa3KZgqwxbkXDFQtPxWPbXsIHF56B77/yO6dDohLyeDyYmpoqy76FEAWN58vHZa/dbpf1+/1+uN1uu0GiNXHAisVaomBdBUg1EcDlcsHv99sflhKXKlhXUKyfqbW1dV/yYnP8Pz+edzm6urowMlL+7oVCCKzYnL25WX9/P157LV7p1dzcjN7e3pwrMIioOgnhgWi5Bqb/9xBNH4Wc/LrTIVGDWNJ1ntMhOGZr9GGMbd5c8v3quo6hoSEem6mWDMD+9Asg3rb7zRm2fy+A32bbKRMFNer43v2xX7Af/lgYt2x41OlwqETOfe67ZZuAkOtIwmKt2Lwady75ACYnJ+0TfCFE0kl+qiUHUkrouo5QKGRPVZjevyAQCEDXdSiKgmAwCNM0oShKvGlgilzAwoULEY1GMTk5WZ4fdi+Px4OL19+c13Pa29vR29vLpkhEdUTxngozciBgTgL+H2Z/AlEam0MPApjIuE25GiFXO3/T3zEyMoJodKzk++7o6EBvby+rCKgadQkhnkq4faOU8sZ8dyKEWA7gCAAnZtuWiYIa1q234or5J8OruPD9dQ86HQ6VwE8WvjfvZQG5Kvagt2pw2b7xgllc8OL/zrjvziUfgGEYkFJCCIFgMAgpJRRFSUoIeL1ehMPhlMsEdF1Pen+ynaALITA2NpZTzPkQQtjJjtbWVpz/wg9yfu7uyBSGhobQ2tpa8riIyHmKaxZM9UMAdMD/bafDoRqVy2eBgYEBoLx58KoUTxKUtieBtdSgpaWlpPulBmBm36REdkopj0jz2BYAQwm3B/fel0QIcRqA6wGcKKXMWmbMREGNc6suXL7gZCxq6ceH/36r0+FQkRJHHVVq383NzYjFYjlNH7CqHTRNw6Ubb8vr9VMlD+474lqMjo4mrcOMRCIzPgBomgaXyzXjg1O29+uo+6/Db4/8KFaOrMEts5cnLX8oRMpEybRKhlvnXAK3253UwyGR4nGh1cckAVE9UxQP0HIVTPf+wNgHnA6HalCmE2Gv14u+vj549jTe6Ow9nr8hGp1x/lMUwzAwNDQEt9td0v0SVdCTABYKIYYRTxBcBCCpRFkIcRiAHwJYKqXcnstOWVdTJ47pWYxfn/RJnD+UaTkKVbtyde0FYDcOTCxVXDmyBhe+9ENctPYmrBxZg5Uja9DX15dTnKVYInHWU9/A/PnzMTS0LwkaiUSSYlQUBaqqJiUJrOqIXE78Ozs78cTSG+LLEwrk8Xhyqqa4Y9EVEELYjQoT/duC0/DnM76AQV9nwXEQUW1R9FMguv8A6Bc7HQrViY6ODsz1Lm3IJAEQr+Ir5Ql9V1cX5s2bxyQBFawamhlKKaMAPgTgAQAvAfiZlPIFIcQXhBBWt9OvAWgC8HMhxDNCiHuz/WysKKgjPXorPrr/23Fw22y4VA3XPfMTp0OiKuP3++2T7N7e3pTr+s988uv4+f7/homJzGsjgfyWI6Tzlgc/Y+8rkTU1IRgMJjVhdLvdWL7hlpz3f9T91xUVH4Cs0yj+fOrnsXXrVkxMTEDXdZz73Hftx65ZdCbm+Lpw3Kz9i46DiGqPUPsgW64D3IdAKAbkGCcjUGoTxpN4/fXX0140aOTGhbbt+6Gt7U/Yvj2nC6JpqaqKwcHBtCONiWqNlPI+APdNu+8/E74/Ld99sqKgzmiKijMHDsNCXy/eM+dYp8Opa7844ErcPnwZfnnQVU6HkpfLN/0YK0fW4KynvpF2mwtfyr0JV6maLybOgY5EIvZSiOlVA+FwGL8+/MN57fuJpTck3c43uZF44p/K+Pg4AoEAWlpasGzdKgDAJ5acjWsWn4mz+g9jkoCowSmKC4r3XEhlAeC9zOlwKAWld61jr73H8ze8uPMubN68mUmCHHSZxxX1fJ/PhwULFjBJQMWTFfxyACsK6tSc5m68f8GpmOVpxR92vIh/7N7odEh1Y/X8FQiFQtizZw8AYPfu3Vg1uAyKosDtdtvr6d/5z+85HOlM+Zwgt7a22j9jNlayYHpzwV8ccGXOjf4u3XhbUtJB07S0fRO2b9+OXx50Vc7vsVVVkMvPr6oqhBD2Vy7VC2c+mTwK7dRZB6Lb04ITevav2LQJIqp+ins+TO0aQJkFBB8Gok9lfxJVhLltkWOv3Rp6M1q7gBd33pXy8Z6enko2TKsJqqqmbHqciaZp6O3tRWtrK4/NRDlgoqCO+Vw6ls07Dm/pWYR7Nj+JNa/92emQat6P512eVAafyDRNBINB+7Z10iuEwIrNqwEAdx34QZz3/PfLEpt1Enz/UR+DlBKmaSIWi9n/zaczPwB7+1vnXJLzwTgUCiWd7BfTnDFb/4Hdu3cXvG9g3/tlxev1enHR2puK2icAXDJ8PFbMOxlNLr3ofRFR/VGUJqDpCpieEwH/XUAgdeNTaizpkgQtLS1FX0GvR4Zh5DX6uLOzEz09PRxJTCUmgSz9A2qZmD7PvBKOOOII+dRTzKJXkpQSf3jjRXzimdVOh1LzSlVqn8jtdid1/s9HS0tLyokC+Vo1uAzd3d14xz9Sj/O6eehiFPv3IjFpksr9R30Mk5OTmJychK7rWScxeDwedHZ2oqWlxV66UIqeBIVYNvc4vK3/cCxs6XXk9RudEOLpDGODKAc8NleelBIy+DtgD/sWNLKXR+9OmRx3uVxY2PoOByKqflujD+c0/tjr9aK/vx+6zuS9E+r92NzSPCCPfFNlliA//IfrK/5esqKgQQghcFLvAXj0tM/i55sex1QkgFte/aPTYdFe4XAYmqbB7XbPqEzIplRJAgAZlxoknuAXmiyRUs54buJygKVP/I/9/R2Lrsi6v1AohK1bt2Lr1q1QVRVNTU0FxQXE+xgUkmS4dPgELG7px2m9B7GUkYjyIoSAMN4K6fk7pH81ICeBqdx7xFDt2xL5PUwz9bGXSYL0sl1c4TIDqhRRvwUFTBQ0Gq/mwWXzTsSrk9vRp7djV2QSN677vdNh1RSPx4NYLFbyUYbRaNTepxACHo8HiqLANE2YpplyzX6pSuisigZrIkI2qdb655I8yKdHgrUMINt+V46swarBZbjstduxanAZHjn+epz82H/n/DqWfJME7xg4HMd274ejOhdwmQERFUUoTRBN/wYz8gog+iEwBjn5TafDojLzN/0dezZudDqMmpRpaSOXGRCVBqceNKjhph6cO/soHNw2B+8cPMrpcGpKKBRCNBqF1+uFy+WCruvQdT3nk+xcSCkRDAbh9/sRDAYRDoft0YaGYcDj8diNfB4/44tFv57VsM8wjIL3sXJkDVaOrEFbW1vR8Uzfb+JEhMT7geQRjStH1hSUJMjHhbOPxqXDJ+CiOcfilN4DmSQgopJRXAshfBdBagcDxrudDofK7PXXX0/7GDvyZ+Z2u2fcZ00z6OvrY5KAKkfKynw5gImCBiaEwFFdC3DN4jNx5YLTnQ6n5vj9fkQiEQSDQQSDQXg8nrK/pmmaCAQCCIVCdoPBUlU2rBxZg/b29qL3c97z38fg4CAMw0g6ULtcroL3eenG29DZ2ZlUkZBYabBqcBl+ddg1Be8/V1cuPB2Htc/FBxeegYUtfWV/PSJqPEIIKPqxQNMnAd+HnQ6Hyihdc2SPx4MhDz+XZTLHeKv9vaZpGBwcxNy5c9mLgKiEuPSA4HV5sGLByTil90DcuuEP+PXWvzsdUk0qtBlhMfr6+nDcw58r2f5O+mPx1QkAcMbjX026vWpwGSKRCFYNLoOmabh042157/OcZ7+DO5d8AOPj4zMeWzmyBhgpONycvG/+KbhwzlvQpPFDCBGVn6I2Ac0fhDTOgJy8CQim7opPtc9aZmiZ3/w2B6OpLV1dXeju7mYFATlDAqKOR5eyooBsc5q68ZmDzsfXDl2O98w51ulwaoqu60VPBMiHoihYObIGZz759ZLutxwTHYDk3gTRaBT3HXFtQfvp7+9PWW64ZsHKgmPL5tzBI7Hm2H/H+xaexiQBEVWc0BZAtH4JaPkOYJTvbx2V10u7fjljBKKmafB6vVi4cCF8Pp9DkdWmsHIhFixYgN7eXiYJiMqEFQWURAiBE3uX4MjO+Ti/vxODyl+BqR/ktQ8TM1NrSg3mpEIyApdQEZIRnPzsxQCA24cvS9lAZ/rVgHLweDy4eP3NBT232RNEzFTwrsGn8cCOA/CD4btw8b/eg6lwfLnE9DL+B9VrcU37Rvu+r4wuwC83HZrXax7RswlPbZ9t39Z1HcFg0L76//ihdwIAvrBzfzy0bTHC0ex/jo556D+T4rRcsuEmrJ7/3pRXYXaZU3jnixfb+3/wLZ/E6X/9Cu468INoUY7BlZvfivGwjomwBxFThRASAhJXLzoL83yDOLx9fkn7TxAR5UsIAeF9K8zYsYD7SCDyDODndIRaEU8QxC8mrBv/NRa0vB0AsKjt7PgGu4A5BgAD2CEeszalVJo/Baj7w+1+M4/NVB0c6h9QCaKSV0EtnNVcO8zICBD5BxD+KxC80+lwHDf9aoDFOgkulyVd55Vt3wCwOfQgJiYmyvp6a8fuRSwWw/6d7yx6XyZM7JCPYZY4Ma/nWbOqM/583uUYU8+A4TkMhlb+vhNUGvU+q7kSeGyuHbHwFjy4ZSf+sO11/OSVZ50Oh7L49eH7kthv//tvHIykdl2+35uwbP4sLGifD0XxOh0O5ajej80tTQPyzYdcWZHXeugvn6n4e8mKAspIcQ0CrkGYnuMA9+FAbAyY+mrW59WjV6d+CyAw435d19M2JCqFYiYR5GrIczpenCjv+ldrUkQpKFByShLsdv0V0WgUo6OjME0TPp8Xs/UzUm/suQDwnArox6NDmbm8gYioWqjuASwdHsBRfQtxSFcfJsMhfPHpR5wOi1JITBJQ/i4YPgBnzt0PJ/QPw8UlBlSN6reggIkCyo2itgPeC2DGJgBFBya+4HRIFRcIzEwSAPFlB+WqzDEMA3PnzgV2lGX3aa0du3dfSWQJzfUuLfk+09kweR98vjBmiRPRnWmYQ/PnAXUW4D4RisIPIURUOzp0Ly5aeAjGQ0FoioJVz9+FTncQUzEX1k52OB1ew7v/qHNKNpmoEWjCxEHNOyAh8N6DLoDX042T+udB5RIDIkcwUUB5UdRmwLcc0nshpP9eCLkTcvKbTodVFom9Fl7eeXfKbTweT9oEQrGEEJgzZw7kjsUIygg0qFBF8sGy2N4PERmFKpSk/Xg8HrjdbvvnL+Q1TJhQoNj7iLT+E4N6CJHAvg9M01831/1aEvefytymeFIiIs3Ur+ddCXhOhHAfDSFEXnEQEVWTFo+Oy/c/Apftd+DeY/NuyMnSNrul/L24c2Y1wa8Pfxu8Xm9FE+c1xbsS8JwE4X4zj81EDmOigAoihAfCd2H8+6bKrM2pNOuUcu3atQBSjz5UVbVs1QTt7e3QNA3oXVe2/1GtFfhSSrTHtiIYDGLu3Ll7Owivy2tfpmkiHA5jfHwcY2NjSeMil/R44kso2jYUFe/0tEIuaQb+kSOiRiGEDuF7V/z7pn9zOJrGtn37dgDbUz7m9/vxoj++3K+1tRVDQ0MVjIyISknUcTNDfoYmykBKiVgslvbxTI8Vq7Ozs2z7nk4IgYGBAUgp88rgm6aJTZs2IRQKpZwGAYBdiYmIqOGkOyYmEkKUrHcPEVGpMVFAlIEQAl1dXdi+fXvKyoFylsUFAgF4PJXtup/vz2OaJiYnJ7Nus337dvT29hYTGhERUVXbujVemSelzLosUdd1DA4OQtf1CkVHRGXBigKixtXd3Y2Wlha88sorSferqlrWkYivv/46mpub9y4DqE6qqmJ4eBiRSAThcBiRSASRSMROqoRCIUSjUVYVEBFRXQsGgxgdHc15+46ODiYJiKiqMVFAlINUJ7qxWAxerxd+v7/kryeEwKxZs6o6SQDE4/T5fBm3iUajZevjQEREVA3ySRIAgMvlKlMkRFQxEsjQV7vmMVFAlINU440URSnb2KOhoSG0tLSUZd+5ikajMM34Xz+32w0gvowg3+oATeOfGSIiqm/5XjSo9gsBRET8BE+Ug7GxsaTbqqpCCJHU2b9UVFVFc3Nzyfebq2g0ih07dmDXrl0A4gmR/fffH7t378bu3bsxb948jiwiIiLaKxaL2UsRPR4PZs2aBdM0EY1GMTExgampqRnPCYfDbGRIVOMEJKceEDUyKSUikQh8Ph/8fj+klNA0rSwTDwzDQHt7e9lPxGOxmN1LQNd1CCEQjUYxNjaGHTt2JP1spmli48aNmJqawty5c5kkICIimqavrw+xWAxdXV1JlXddXV2IRqPYvHlzUsIgEAigra3NgUiJiHLDRAFRFkIIzJ49G0D8BHtqagpNTU0QQiAYDGJ8fBw7duwo6jWam5sxODhY1lLEUCiE7du3Y3JyMikRYE1WiEQi9lKD6aampuDz+dDU1FS2+IiIiGqRqqoZRxprmobW1lZMTU3B4/EgFAph165daGlpydrnh4iqHCsKiAiIfxhI7B1gGAYMw4Df709ZWpiL5uZmg3sV0QAADnpJREFUDA0NFT0ZwKp8sL7C4TCEENB1HRMTE9i9e3fKpoKhUAhAfFRTpikO4XAYUkpWFBAREeXJSrS3tLQgGo1i9+7d2Lx5MxYtWsTJQERUlZgoICqBjo6OGYkCTdPQ2dkJr9eLaDSKaDSKWCwG0zQhpbQbA86aNSvnDwlSSoTDYYRCoaT/WqMJi5Gt30IkEsHatWsxd+5cuwqBiIiIsnO73Vi0aBFCoRCampoQDocxNTWF0dFRdHZ2MglPVKtYUUBEmbS2tiIQCGDnzp0A4msSe3p6SnKVwDRNTE1NYc+ePZiYmChLbwTrdbJVFViVCkwUEBER5cftdttThIaGhrB+/Xps27YNk5OTGBwc5JQgIqoq/ItEVCKdnZ1oaWmBlLJkaw4nJiawdevWoqsFcpVLYiPV8gUiIiLKnVV1aCUKNmzYgDlz5jART1RLJIDU7b3qAhMFRCUQi8Wwfv16RKNRAPGlCH19fXmVEpqmaS8jCIVC8Pv9mJiYKFfIBRFCwOVyOR0GERFRzWtvb8f27dvt47+VLODYRCKqBkwUEBVJSomtW7faSQIAGB0dRSgUskcfCSGgqiq8Xu+MyQamaWJ0dHTGWMJqNDQ0BMMwnA6DiIio5qmqir6+PoyNjSEQCCAWi+HVV1/FvHnzeKwlqhGijittmSggKtLOnTuxZ8+eGfdPTU2lnIRgGAaamprgcrkgpcSOHTuSkgxOyrTEoaOjI2niAxERERWnvb0d7e3tkFJiYmICIyMj2LRpE+bPn8+eBUTkqKI7rQkhrhZCvCyEeEEI8dVSBEVUK/bs2YM33ngjr+cEAgHs2LEDW7duxa5du6omSWAYRspEgaZp8Pl8UBSF/QmIagSPzUS1RQiBlpYWLFiwAM3NzRXrTURElE5RqUohxMkAzgFwiJQyJIToKU1YRNVvamoKIyMjRe0jHA7DMAwEAoESRVUYn88H0zTR1tYGt9sNj8djd2eevlSCiKobj81EtcvtdqO/v9/pMIgoV3V8Ea3YmqYrAXxZShkCACnl9uJDIqp+pmlCSone3l67+WAoFEI0Gq3aq+6KosDlctlJAI/HY3/P8kaiusJjMxERERWl2LODRQCOF0L8N4AggI9JKZ8sPiyi6qYoCpqamtDU1DTjMSklTNNM+orFYjPus+5XFAVutzvl9kIIKIpif6mqmnQ7l8dUVYUQIq8JDERU03hsJiIiKjvZ2BUFQoiHAPSmeOj6vc/vAHA0gCMB/EwIMU+muKQqhHg/gPfvvRkSQjxfcNT1pwvATqeDqBJ8L5Lx/diH70Uyvh/JFjsdQCXx2FwR/H9sH74Xyfh+7MP3Ihnfj2QNdWyuN1kTBVLK09I9JoS4EsBdez98PCGEMBH/H2RHiv3cCODGvc97Skp5RMFR1xm+H/vwvUjG92MfvhfJ+H4kE0I85XQMlcRjc/nx/diH70Uyvh/78L1IxvcjWd0fmyXquqKg2KkHdwM4GQCEEIsAuMEsGhERkZPuBo/NREREVIRiexSsArBqb6liGMBlqUobiYiIqGJ4bCYiIqoE0+kAyqeoRIGUMgxgeQFPvbGY161DfD/24XuRjO/HPnwvkvH9SMb3Yy8em0uG78c+fC+S8f3Yh+9FMr4fyfh+1DDBiwxEREREREREuWs1+uQxwysq8lr3v/Slpyvd/6LYHgVEREREREREVEccTRQIIa4WQrwshHhBCPFVJ2OpBkKIjwohpBCiy+lYnCSE+NrefxfPCSF+KYRoczqmShNCLBVC/EsIsU4I8Smn43GSEGJICPGIEOLFvX8rrnE6JqcJIVQhxD+EEL92OhanCSHahBB37v2b8ZIQ4i1Ox1TreGxOxmNzHI/NPDYn4rF5Jh6b92moY7OUlflygGOJAiHEyQDOAXCIlPIAAP/jVCzVQAgxBOAMAJucjqUKPAjgQCnlwQDWAvi0w/FUlBBCBfA9AGcCWALgPUKIJc5G5agogI9KKZcgPhf+qgZ/PwDgGgAvOR1Elfg2gPullPsBOAR8X4rCY3MyHpuT8NjMY3MiHptn4rF5Hx6b64CTFQVXAviylDIEAFLK7Q7GUg2+CeATiE/kbGhSyt9JKaN7bz4OYNDJeBxwFIB1UsoNe5uS3YH4B/eGJKV8XUr5973fTyB+sBlwNirnCCEGAbwNwE1Ox+I0IUQrgBMA/AiIN/GTUo45GlTt47E5GY/Ne/HYzGNzIh6bk/HYvE9DHZslAFNW5ssBTiYKFgE4XgjxNyHEH4QQRzoYi6OEEOcA2CKlfNbpWKrQSgC/dTqIChsAsDnh9gga+OCbSAgxF8BhAP7mcChO+hbiJy51PJAnZ8MAdgC4eW+5501CCJ/TQdU4Hpv34rE5Ix6beWy28dgMgMfmRDw214mixiNmI4R4CEBvioeu3/vaHYiXKx0J4GdCiHn1Ous5y3txHeKljQ0j0/shpbxn7zbXI17atrqSsVF1EkI0AfgFgA9LKcedjscJQoi3A9gupXxaCHGSw+FUAw3A4QCullL+TQjxbQCfAvAZZ8Oqbjw278NjczIemylfPDbz2JxCAx2bnesfUAllTRRIKU9L95gQ4koAd+398PGEEMIE0IV4BqrupHsvhBAHIZ55e1YIAcRL+f4uhDhKSrmtgiFWVKZ/GwAghLgcwNsBnFqvH1Az2AJgKOH24N77GpYQwoX4B5HVUsq7nI7HQccCOFsIcRYAHUCLEOLHUsrlDsfllBEAI1JK6yrWnYh/GKEMeGzeh8fmZDw2Z8Rj8zQ8Ntt4bE7GY3OdcHLpwd0ATgYAIcQiAG4AOx2MxxFSyn9KKXuklHOllHMR/5/r8Hr+IJKNEGIp4uVbZ0sp/U7H44AnASwUQgwLIdwALgJwr8MxOUbEP6X/CMBLUspvOB2Pk6SUn5ZSDu79W3ERgIcb+IMI9v6d3CyEWLz3rlMBvOhgSPXgbvDYzGNzCjw289iciMfmfXhsTsZjc/0oa0VBFqsArBJCPA8gDOCyBsxOU2rfBeAB8ODeKzmPSyk/4GxIlSOljAohPgTgAQAqgFVSyhccDstJxwK4BMA/hRDP7L3vOinlfc6FRFXkagCr935w3wBghcPx1DoemykdHpt5bE7EYzNl0jjH5jo+RAoe/4mIiIiIiIhy16r3ymOGLq3Ia92/7mtPSymPqMiL7eVkRQERERERERFRbarji+5O9iggIiIiIiIioirDigIiIiIiIiKifEgAJisKiIiIiIiIiKgBMFFARESOEUKsEkJs39tlP5ft3yWEeFEI8YIQYk254yMiImo0PDbnSgLSrMyXA5goICIiJ90CYGkuGwohFgL4NIBjpZQHAPhw+cIiIiJqWLeAx+aGx0QBERE5Rkr5RwCjifcJIeYLIe4XQjwthHhMCLHf3ofeB+B7Usrde5+7vcLhEhER1T0em/MgZWW+HMBEARERVZsbAVwtpXwTgI8B+P7e+xcBWCSE+LMQ4nEhRE5XO4iIiKhoPDY3GE49ICKiqiGEaAJwDICfCyGsuz17/6sBWAjgJACDAP4ohDhISjlW4TCJiIgaBo/NadT51AMmCoiIqJooAMaklIemeGwEwN+klBEArwoh1iL+4eTJCsZHRETUaHhsbkBcekBERFVDSjmO+AeNCwFAxB2y9+G7Eb9iASFEF+LljhscCJOIiKhh8NicAXsUEBERlZ4Q4icA/gpgsRBiRAjxXgAXA3ivEOJZAC8AOGfv5g8A2CWEeBHAIwA+LqXc5UTcRERE9YrHZgIAIR3KUBARERERERHVolb3LHlMz7sr8lr3b/nO01LKIyryYnuxooCIiIiIiIiIbEwUEBEREREREZGNUw+IiIiIiIiI8uJco8FKYEUBEREREREREdlYUUBERERERESUDwnANJ2OomxYUUBERERERERENlYUEBEREREREeWLPQqIiIiIiIiIqBGwooCIiIiIiIgoX6woICIiIiIiIqJGwIoCIiIiIiIiorxIwGRFARERERERERE1AFYUEBEREREREeVDAlKaTkdRNqwoICIiIiIiIiIbKwqIiIiIiIiI8sUeBURERERERETUCFhRQERERERERJQvyYoCIiIiIiIiImoATBQQERERERERkY1LD4iIiIiIiIjyISVgcjwiERERERERETUAVhQQERERERER5YvNDImIiIiIiIioEbCigIiIiIiIiChPkj0KiIiIiIiIiKgRsKKAiIiIiIiIKC+SPQqIiIiIiIiIqDGwooCIiIiIiIgoHxKAyYoCIiIiIiIiImoArCggIiIiIiIiypfk1AMiIiIiIiIiagCsKCAiIiIiIiLKgwQg2aOAiIiIiIiIiBoBKwqIiIiIiIiI8iElexQQERERERERUWNgooCIiIiIiIiIbEwUEBEREREREeVJmrIiX9kIIZYKIf4lhFgnhPhUisc9Qoif7n38b0KIudn2yUQBERERERERUQ0SQqgAvgfgTABLALxHCLFk2mbvBbBbSrkAwDcBfCXbfpkoICIiIiIiIsqXNCvzldlRANZJKTdIKcMA7gBwzrRtzgFw697v7wRwqhBCZNopEwVEREREREREtWkAwOaE2yN770u5jZQyCmAPgM5MO+V4RCIiIiIiIqI8TGD3Aw/JO7sq9HK6EOKphNs3SilvLOcLMlFARERERERElAcp5VKnY9hrC4ChhNuDe+9Ltc2IEEID0ApgV6adcukBERERERERUW16EsBCIcSwEMIN4CIA907b5l4Al+39/gIAD0spM45TYEUBERERERERUQ2SUkaFEB8C8AAAFcAqKeULQogvAHhKSnkvgB8BuF0IsQ7AKOLJhIxElkQCERERERERETUQLj0gIiIiIiIiIhsTBURERERERERkY6KAiIiIiIiIiGxMFBARERERERGRjYkCIiIiIiIiIrIxUUBERERERERENiYKiIiIiIiIiMjGRAERERERERER2f4/W+d/kYYTdvsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1440x720 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Set up two subplots\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(20, 10))\n",
+    "for axis in axes:\n",
+    "    axis.set(xlim=(-6e6, 6e6), ylim=(-6e6, 6e6))\n",
+    "    axis.set_aspect(\"equal\", \"box\")\n",
+    "\n",
+    "# Plot forecasts together with world map data\n",
+    "world_north.plot(ax=axes[0], color=\"lightgray\")\n",
+    "geodata_north.plot(ax=axes[0], column=\"sea_ice_concentration_mean\")\n",
+    "world_south.plot(ax=axes[1], color=\"lightgray\")\n",
+    "geodata_south.plot(ax=axes[1], column=\"sea_ice_concentration_mean\")\n",
+    "\n",
+    "# Plot a single legend for both subplots\n",
+    "axes[0].collections[0].set_clim(0.0, 1.0)\n",
+    "legend = fig.colorbar(axes[0].collections[0], ax=axes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43e87c6d",
+   "metadata": {},
+   "source": [
+    "You have now succesfully retrieved `IceNet` data from our API and plotted it on a world map. 🎉"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/geoapi/requirements.txt
+++ b/geoapi/requirements.txt
@@ -1,0 +1,5 @@
+geopandas
+jupyter
+matplotlib
+pygeos
+Shapely


### PR DESCRIPTION
These notebooks were previously stored within the icenet-geoapi repository, but I've moved them to draw some parity with other repositories, especially given that repository is now solely a pythonic function app for deployment to the cloud. It just makes sense for notebooks not to be included in deployable / packaged repositories, but as with the icenet library itself we need to define a strategy for versioning over time. 

In the meantime, them sitting here should suffice.