### PR TITLE
Add pre-commit hook to strip notebook output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.6.1
+  hooks:
+    - id: nbstripout
+      files: '.*\.ipynb$'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## icenet-notebooks
 
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+
 This repository contains instructional notebooks that describe how to use the library and pipelining utilities built around it. 
 
 ### Instructional notebooks
@@ -26,4 +28,15 @@ Any other notebook is likely related to events or presentations that have been g
 
 Please fork and raise PRs, _contributions are most welcome!_
 
+### Removing notebook outputs
+
+Sometimes it's a good idea to strip the output from notebooks prior to commiting changes and opening pull requests, to make it easier to compare.
+
+This can be done by manually removing the output in the Jupyter notebooks, but is simpler using the `nbstripout` tool running as a pre-commit hook.
+
+This requires installation of `nbstripout` and `pre-commit` via `pip install nbstripout pre-commit` running in your conda environment (note that both can alternatively be installed from conda-forge).
+
+Finally, install the pre-commit hook by running `pre-commit install` (making sure to be in your clone of this repository) which will install the pre-commit hooks defined in the `.pre-commit-config.yaml` file in this repository.
+
+Now making any commits to `*.ipynb` files (i.e. jupyter notebooks) will run `nbstripout` against them before commiting.
 


### PR DESCRIPTION
I'm happy to debate whether this is a good idea for this repo or not.

This PR adds a pre-commit hook to use [nbstripout](https://github.com/kynan/nbstripout/) to remove output from notebooks before committing.

Sometimes it's a good idea to remove output from notebooks so that they can be more easily compared in version control (i.e. changes are only in the cells, not in the output) or to remove potentially sensitive information, including usernames and filepaths in output logs).

This is potentially debatable in this particular case, since some of the existing output might be desirable in these tutorial-style notebooks.

Thoughts?