### PR TITLE
Reorganise the first notebook to remove pipeline sections

### DIFF
--- a/01.cli_demonstration.ipynb
+++ b/01.cli_demonstration.ipynb
@@ -18,11 +18,12 @@
     "\n",
     "### Highlights\n",
     "The key stages of an end to end run are: \n",
-    "* [Setup](#Setup)\n",
-    "* [Download](#Download) \n",
-    "* [Process](#Process)\n",
-    "* [Train](#Train)\n",
-    "* [Predict](#Predict)\n",
+    "\n",
+    "0. [Setup](#0.-Setup)\n",
+    "1. [Download](#1.-Download) \n",
+    "1. [Process](#2.-Process)\n",
+    "1. [Train](#3.-Train)\n",
+    "1. [Predict](#4.-Predict)\n",
     "\n",
     "### Contributions\n",
     "#### Notebook\n",
@@ -49,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 0. Setup\n",
     "\n",
     "### Prerequisites\n",
     "\n",
@@ -62,7 +63,7 @@
     "  * A development environment such as [visual studio code](https://code.visualstudio.com/) which [can run jupyter notebooks](https://code.visualstudio.com/docs/datascience/jupyter-notebooks) (Note: for vscode, you'll need to install `ipykernel` in our conda environment later on), or\n",
     "  * A [Google colab](https://colab.research.google.com/) instance.\n",
     "* A working installation of [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html),\n",
-    "* Wherever you run, you want GPUs for training (predictions run fine without)\n",
+    "* GPUs are required for training but not required for predictions.\n",
     "* Knowledge of [Git](https://swcarpentry.github.io/git-novice/), [python](https://swcarpentry.github.io/python-novice-inflammation/) and [shell](https://swcarpentry.github.io/shell-novice/) (links to Carpentries courses on these topics)\n",
     "* There are a few external facilities that we interface with, which you will need to set up if you haven't already.\n",
     "  * Data sources under [Climate and Sea Ice Data](#Climate-and-Sea-Ice-Data) including an account and API token for the [Climate Data Store](https://cds.climate.copernicus.eu/#!/home) (detailed later)\n",
@@ -129,7 +130,7 @@
     "\n",
     "The rule of thumb to follow: \n",
     "\n",
-    "* Use the pipeline repository if you want to run the end to end IceNet processing out of the box.\n",
+    "* Use the [pipeline repository](https://github.com/icenet-ai/icenet-pipeline) if you want to run the end to end IceNet processing out of the box.\n",
     "* Adapt or customise this process using `icenet_*` commands described in this notebook and in the scripts contained in [the pipeline repo](https://github.com/icenet-ai/icenet-pipeline).\n",
     "* For ultimate customisation, you can interact with the IceNet repository programmatically (which is how the CLI commands operate.) For more information look at the [IceNet CLI implementations](https://github.com/JimCircadian/icenet2/blob/main/setup.py#L32) and the [library notebook](03.library_usage.ipynb), along with the [library documentation](#TODO). "
    ]
@@ -143,13 +144,14 @@
     "tags": []
    },
    "source": [
-    "## Download\n",
+    "## 1. Download\n",
     "\n",
     "Now we can get started, with the first step of downloading the data.\n",
     "\n",
     "### Mask data\n",
     "\n",
-    "IceNet relies on some generated masks for training/prediction, which can be automatically generated very easily using `icenet_data_masks {north,south}`."
+    "IceNet relies on some generated masks for training/prediction, which can be automatically produced very easily using `icenet_data_masks {north,south}`, which downloads and processes the data required.\n",
+    "Once this has been run once, it does not need to be run again since the mask files are stored on disk."
    ]
   },
   {
@@ -194,7 +196,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`icenet_data_era5` downloads <abbr title=\"ERA5 provides hourly estimates of a large number of atmospheric, land and oceanic climate variables. The data cover the Earth on a 30km grid and resolve the atmosphere using 137 levels from the surface up to a height of 80km. ERA5 includes information about uncertainties for all variables at reduced spatial and temporal resolutions.\">ERA5</abbr> (European Centre for Medium Range Weather Forecasting Reanalysis) data. For more information on the ERA5 data, [see the Copernicus page](https://climate.copernicus.eu/climate-reanalysis)."
+    "`icenet_data_era5` downloads <abbr title=\"ERA5 provides hourly estimates of a large number of atmospheric, land and oceanic climate variables. The data cover the Earth on a 30km grid and resolve the atmosphere using 137 levels from the surface up to a height of 80km. ERA5 includes information about uncertainties for all variables at reduced spatial and temporal resolutions.\">ERA5</abbr> (European Centre for Medium Range Weather Forecasting Reanalysis) data. For more information on the ERA5 data, [see the Copernicus page](https://climate.copernicus.eu/climate-reanalysis).\n",
+    "\n",
+    "We can use the `--help` flag for the command line tools to print the help text and explanation of the options. Some of these help commands can take up to a minute to run, so don't worry if you have to wait a moment."
    ]
   },
   {
@@ -212,10 +216,10 @@
    "source": [
     "The `-vars` flag is used for specifying the variables from ERA5 that we want as follows:\n",
     "\n",
-    "* `tas`: `2m_temperature`,\n",
-    "* `uas`: `10m_u_component_of_wind`,\n",
-    "* `vas`: `10m_v_component_of_wind`,\n",
-    "* `zg`: `geopotential`.\n",
+    "* `tas`: `2 metre temperature`,\n",
+    "* `uas`: `10 metre U wind component`,\n",
+    "* `vas`: `10 metre V wind component`,\n",
+    "* `zg`: `Geopotential height`.\n",
     "\n",
     "These are the four we'll use here, though others are available.\n",
     "\n",
@@ -262,7 +266,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To run `icenet_data_sic` you will need the `eccodes` package installed. If you have used `pip` to install IceNet, you will need to use `conda` to install `eccodes` by running `conda install -c conda-forge eccodes` at the command line. Alternatively, the ECMWF provide alternative instructions for installing eccodes [here](https://confluence.ecmwf.int/display/ECC/ecCodes+installation#ecCodesinstallation-Python3bindings)."
+    "To run `icenet_data_sic` you will need the `eccodes` package installed. If you have used `pip` to install IceNet, you will need to use `conda` to install `eccodes` by running `conda install -c conda-forge eccodes` at the command line. Alternatively, the ECMWF provide alternative instructions for installing eccodes [here](https://confluence.ecmwf.int/display/ECC/ecCodes+installation#ecCodesinstallation-Python3bindings).\n",
+    "\n",
+    "Here we pass two dates bounding the data range to be downloaded using the `-d` option with the dates in `YYYY-M-D` format."
    ]
   },
   {
@@ -307,7 +313,7 @@
     "tags": []
    },
    "source": [
-    "## Process\n",
+    "## 2. Process\n",
     "\n",
     "Processing takes the data made available through the source data store and undertakes the necessary normalisation for use as input channels to the UNet architecture. This intermediary step means that the original source data can be reused numerous times with varying training, validation and test date setups.\n",
     "\n",
@@ -348,6 +354,9 @@
     "Consulting the command options will make the above more obvious (as well as further options) but a few things we can note that are helpful: \n",
     "\n",
     "* Options `-ns`, `-ne`, `-vs`, `-ve`, `-ts`, `-te`, which correspond to training, validation and test sets, allow ranges to be comma-delimited. The above example produces a split training set, for example, that spans the first 4 months of 2020.\n",
+    "  * `-ns` specifies the *start* of the training set, `-ne` specifies the *end*.\n",
+    "  * `-vs` specifies the *start* of the validation set, `-ve` specifies the *end*.\n",
+    "  * `-ts` specifies the *start* of the test set, `-te` specifies the *end*.\n",
     "* These date ranges can be randomised and subsampled using `-d`, __though this is still a bit experimental__\n",
     "* The `-l` option (which is for `--lag`) specified the number of days back we look at input data variables for the output in question.\n",
     "\n",
@@ -419,7 +428,7 @@
     "tags": []
    },
    "source": [
-    "## Train\n",
+    "## 3. Train\n",
     "\n",
     "Once the dataset is prepared, running a network is then as simple as using `icenet_train` with the appropriate parameters. Some key parameters are illustrated in the following commands:\n",
     " "
@@ -435,6 +444,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "The following runs demonstrate using the aforementioned dataset with the following options:\n",
+    "\n",
+    "* in `-b` batches of 2 (`-b 2`)\n",
+    "* for a run of `-e` 10 epochs (`-e 10`)\n",
+    "* using `-m` for multiprocessing we enable up to `-w` 4 process workers to load data at a time (`-w 4`)\n",
+    "* into a data queue `-qs` of length 4 (`-qs 4`)\n",
+    "* We could specify a `-r` ratio we use only 0.2x of the files from the dataset (_useful when testing on a low power machine with a large dataset, but unnecessary with our example here_) \n",
+    "* supplying a UNet built with 0.6x the `-n` numbers of filters as normal. (`-n 0.6`)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -447,6 +476,15 @@
    "outputs": [],
    "source": [
     "!icenet_train notebook_data notebook_testrun 42 -b 2 -e 10 -m -qs 4 -w 4 -n 0.6 -nw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this second command, we can pick up the training from the previous run above and continue training for another 2 epochs, as set by the `-e 2` option.\n",
+    "\n",
+    "This can be useful when wanting to continue training runs after having run them previously (if say for example you realised later down the line that you did not run for long enough, or due to resource constraints or any other reason, you had to stop)."
    ]
   },
   {
@@ -467,22 +505,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
-    "These runs demonstrate using the aforementioned dataset, in `-b` batches of 4 for a run of `-e` five epochs. Using `-m` for multiprocessing we enable up to `-w` four process workers to load data at a time into a data queue `-qs` of length four. We could specify a `-r` ratio we use only 0.2x of the files from the dataset (_useful when testing on a low power machine with a large dataset, but unnecessary with our example here_) supplying a UNet built with 0.6x the `-n` numbers of filters as normal. \n",
-    "\n",
-    "With the second command we `-p` pickup the output weights from the previous run to continue training.\n",
+    "### Notes on training and prediction\n",
     "\n",
     "There are a few things to note about the `icenet_train` and `icenet_predict` (see [the prediction section below](#Predict)) commands and the switches they provide: \n",
     "\n",
     "* Common switches such as `-n` should be applied consistently between training and prediction. \n",
-    "* These commands work with __individual network runs__ (see the next section).\n"
+    "* These commands work with __individual network runs__ (see the next section)."
    ]
   },
   {
@@ -494,7 +524,7 @@
     "tags": []
    },
    "source": [
-    "## Predict\n",
+    "## 4.  Predict\n",
     "\n",
     "To run individual sets through the test network from the test dataset we produced earlier can be easily achieved. The steps are to create a date file, which can be produced from the configuration created by `icenet_process` in the [processing section](#Process). This date file then can be supplied to the `icenet_predict` command to produce files using either cached data (useful for test data prepared at the same time as the training and validation sets) or directly from the normalised data (as is the case for nearly all data that isn't part of the training run.)"
    ]
@@ -503,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`icenet_predict` takes a file containing dates to make predictions for. First we can make a file, here called `testdates.csv` to pass to `icenet_predict` in the next step. (Note that the more IceNet Pipeline method uses a more elegant system for providing dates; or if using the python interface, can be provided to the `predict_forecast` function as a list of dates - see 03.library_usage)"
+    "`icenet_predict` takes a file containing dates to make predictions for. First we can make a file, here called `testdates.csv` to pass to `icenet_predict` in the next step. (Note that the more advanced IceNet Pipeline method uses a more elegant system for providing dates; or if using the python interface, can be provided to the `predict_forecast` function as a list of dates - see 03.library_usage)"
    ]
   },
   {
@@ -517,7 +547,7 @@
    },
    "outputs": [],
    "source": [
-    "!echo \"2020-04-01\\n2020-04-02\" | tee testdates.csv"
+    "!printf \"2020-04-01\\n2020-04-02\" | tee testdates.csv"
    ]
   },
   {
@@ -577,7 +607,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The individual numpy outputs, samples and sample weights are deposited into `/results/predict` for each ensemble member. To generate __a CF-compliant NetCDF containing the forecasts requested__ we need to run `icenet_output`, these can then be post-processed. "
+    "The individual numpy outputs, samples and sample weights are deposited into `/results/predict`. To generate __a CF-compliant NetCDF containing the forecasts requested__ we need to run `icenet_output`, these can then be post-processed. "
    ]
   },
   {
@@ -612,6 +642,13 @@
    "outputs": [],
    "source": [
     "!icenet_plot_forecast south results/predict/example_south_forecast.nc 2020-04-01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From the 7 days forecast above, lets pick one of the images and display it here:"
    ]
   },
   {


### PR DESCRIPTION
**Note**: This is a draft PR for now, would recommend waiting for @matscorse's branch moving the pipeline elements to a separate notebook.

This branch/pr removes the parts of the first notebook that relate to the pipeline, in favour of having that explanation in a separate notebook (to come, I believe @matscorse is working on it).

Happy to be roundly disagreed with on this, so don't pull your punches!

@matscorse and I (hopefully I'm not misrepresenting here!) felt when going through this first notebook that the combined introduction of IceNet as a whole, with the pipeline components of running it (including switching directories/repositories etc) was a bit too challenging for an introductory notebook.

However, I appreciate that the intention here may have been to use the maximum convenience of the pipeline structure to ease the out of the box end-to-end running of IceNet.

My aim here has been to slightly simplify the operations to allow the user to better absorb the steps of running IceNet at the command-line.

Additionally, it is my feeling that the user should be able to run IceNet in its most simple operation by simply pip installing it (`pip install icenet` as in the IceNet readme), which wasn't quite the case here, even though the pipeline shell scripts do introduce extra convenience.


:warning: I recommend enabling rich notebook diffs on GitHub if you don't have it on already. https://github.blog/changelog/2023-03-01-feature-preview-rich-jupyter-notebook-diffs/